### PR TITLE
Unify AFL team codes: remove hardcoded DFL/AFL team mappings

### DIFF
--- a/bin/run_dfl_round_info_generator.sh
+++ b/bin/run_dfl_round_info_generator.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export CLASSPATH=$APP_HOME/target/dflmngr.jar:$APP_HOME/target/dependency/*
+java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler

--- a/src/main/java/net/dflmngr/handlers/PreSeasonStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/PreSeasonStatsHandler.java
@@ -18,7 +18,6 @@ import net.dflmngr.model.entity.DflPreseasonScores;
 import net.dflmngr.model.service.DflPlayerService;
 import net.dflmngr.model.service.DflPreseasonScoresService;
 import net.dflmngr.model.service.GlobalsService;
-import net.dflmngr.utils.DflmngrUtils;
 
 public class PreSeasonStatsHandler extends BaseHandler {
 
@@ -48,8 +47,8 @@ public class PreSeasonStatsHandler extends BaseHandler {
 			String homeTeam = teams.split("-")[0];
 			String awayTeam = teams.split("-")[2];
 			
-			List<DflPlayer> players = dflPlayerService.getByTeam(DflmngrUtils.aflDflTeamMap.get(homeTeam.toUpperCase()));
-			players.addAll(dflPlayerService.getByTeam(DflmngrUtils.aflDflTeamMap.get(awayTeam.toUpperCase())));
+			List<DflPlayer> players = dflPlayerService.getByTeam(homeTeam.toUpperCase());
+			players.addAll(dflPlayerService.getByTeam(awayTeam.toUpperCase()));
 			
 			List<DflPreseasonScores> preseasonScores = calculatePreseasonScore(round, players, stats);
 			dflPreseasonScoresService.insertAll(preseasonScores, false);

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -39,7 +39,6 @@ import net.dflmngr.model.service.DflTeamScoresService;
 import net.dflmngr.model.service.DflTeamService;
 import net.dflmngr.model.service.GlobalsService;
 import net.dflmngr.model.service.RawPlayerStatsService;
-import net.dflmngr.utils.DflmngrUtils;
 
 public class ScoresCalculatorHandler extends BaseHandler {
 
@@ -268,7 +267,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			if(playerScore == null) {
 				loggerUtils.log("info", "Selected player: team={} teamPlayerId={} playerId={} has no score recorded",
 								selectedPlayer.getTeamCode(), selectedPlayer.getTeamPlayerId(), selectedPlayer.getPlayerId());
-				if(playedTeams.contains(DflmngrUtils.dflAflTeamMap.get(player.getAflClub()))) {
+				if(playedTeams.contains(player.getAflClub())) {
 					loggerUtils.log("info", "AFL team has played, marking as DNP");
 					selectedPlayer.setDnp(true);
 					selectedPlayer.setScoreUsed(false);
@@ -310,7 +309,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 
 				scores.put(selectedPlayer.getPlayerId(), playerScore.getScore());
 
-				selectedPlayer.setHasPlayed(playedTeams.contains(DflmngrUtils.dflAflTeamMap.get(player.getAflClub())));
+				selectedPlayer.setHasPlayed(playedTeams.contains(player.getAflClub()));
 				selectedPlayer.setDnp(false);
 
 				if(selectedPlayer.isEmergency() == 0) {

--- a/src/main/java/net/dflmngr/utils/DflmngrUtils.java
+++ b/src/main/java/net/dflmngr/utils/DflmngrUtils.java
@@ -77,52 +77,5 @@ public class DflmngrUtils {
 	    AMPM.put("PM", Calendar.PM);
 	};
 
-	public static final Map<String, String> dflAflTeamMap;
-	static
-	{
-		dflAflTeamMap = new HashMap<String, String>();
-		dflAflTeamMap.put("Adel", "ADEL");
-		dflAflTeamMap.put("Bris", "BL");
-		dflAflTeamMap.put("Bull", "WB");
-		dflAflTeamMap.put("Carl", "CARL");
-		dflAflTeamMap.put("Coll", "COLL");
-		dflAflTeamMap.put("Ess", "ESS");
-		dflAflTeamMap.put("Freo", "FREO");
-		dflAflTeamMap.put("Geel", "GEEL");
-		dflAflTeamMap.put("Gold", "GCFC");
-		dflAflTeamMap.put("GWS", "GWS");
-		dflAflTeamMap.put("Haw", "HAW");
-		dflAflTeamMap.put("Melb", "MELB");
-		dflAflTeamMap.put("Nth", "NMFC");
-		dflAflTeamMap.put("Port", "PORT");
-		dflAflTeamMap.put("Rich", "RICH");
-		dflAflTeamMap.put("StK", "STK");
-		dflAflTeamMap.put("Syd", "SYD");
-		dflAflTeamMap.put("WCE", "WCE");
-	}
-
-	public static final Map<String, String> aflDflTeamMap;
-	static
-	{
-		aflDflTeamMap = new HashMap<String, String>();
-		aflDflTeamMap.put("ADEL", "Adel");
-		aflDflTeamMap.put("BL", "Bris");
-		aflDflTeamMap.put("WB", "Bull");
-		aflDflTeamMap.put("CARL", "Carl");
-		aflDflTeamMap.put("COLL", "Coll");
-		aflDflTeamMap.put("ESS", "Ess");
-		aflDflTeamMap.put("FRE", "Freo");
-		aflDflTeamMap.put("GEEL", "Geel");
-		aflDflTeamMap.put("GCFC", "Gold");
-		aflDflTeamMap.put("GWS", "GWS");
-		aflDflTeamMap.put("HAW", "Haw");
-		aflDflTeamMap.put("MELB", "Melb");
-		aflDflTeamMap.put("NMFC", "Nth");
-		aflDflTeamMap.put("PORT", "Port");
-		aflDflTeamMap.put("RICH", "Rich");
-		aflDflTeamMap.put("STK", "StK");
-		aflDflTeamMap.put("SYD", "Syd");
-		aflDflTeamMap.put("WCE", "WCE");
-	}
 
 }


### PR DESCRIPTION
## Summary

- Remove `dflAflTeamMap` and `aflDflTeamMap` static maps from `DflmngrUtils`
- `ScoresCalculatorHandler` now uses `player.getAflClub()` directly instead of translating through the map
- `PreSeasonStatsHandler` now passes the AFL team code directly to `dflPlayerService.getByTeam()`
- Remove unused `DflmngrUtils` imports from both handlers

## Note

Requires a database migration to update `dfl_player.afl_club` and `dfl_unmatched_player.afl_club` values from DFL short codes (`Adel`, `Bris`, `Bull`, etc.) to AFL codes (`ADEL`, `BL`, `WB`, etc.) to match `afl_team.team_id`.