### PR TITLE
Remove globals aflTeamMap lookup from AflPlayerLoaderHandler

### DIFF
--- a/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
@@ -136,7 +136,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		Map<Integer, AflPlayer> aflPlayerUpdates = new HashMap<>();
 
 		for(AflPlayer aflPlayer : aflPlayers) {
-			String aflPlayerCrossRef = (aflPlayer.getName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + globalsService.getAflTeamMap(aflPlayer.getTeamId().toLowerCase())).toLowerCase();
+			String aflPlayerCrossRef = (aflPlayer.getName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflPlayer.getTeamId()).toLowerCase();
 			loggerUtils.log("info", "Searching for player: {}", aflPlayerCrossRef);
 			DflPlayer dflPlayer = dflPlayerCrossRefs.get(aflPlayerCrossRef);
 
@@ -171,7 +171,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 		    for(AflPlayer aflPlayer : aflUnmatchedPlayers) {
 
-		    	String aflTeamName = globalsService.getAflTeamMap(aflPlayer.getTeamId().toLowerCase());
+		    	String aflTeamName = aflPlayer.getTeamId().toLowerCase();
 
 		    	String aflCheckOne = (aflPlayer.getName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflTeamName).toLowerCase();
 


### PR DESCRIPTION
## Summary

- `AflPlayerLoaderHandler` was looking up a `globals` DB table (`groupCode=aflTeamMap`) to translate AFL team IDs to DFL short codes for cross-reference matching
- Now that `dfl_player.afl_club` uses the same AFL team codes as `afl_team.team_id`, the translation is no longer needed
- The cross-ref string on the AFL side now uses `aflPlayer.getTeamId()` directly, which lowercases to match the DFL side (`dflPlayer.getAflClub().toLowerCase()`)

## Note

The `globals` `aflTeamMap` entries can be removed from the DB once this is deployed, though leaving them causes no harm.