### PR TITLE
Fix NPE and IndexOutOfBounds bugs in CallumChambersHandler

### DIFF
--- a/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
+++ b/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
@@ -47,97 +47,101 @@ public class CallumChambersHandler extends BaseHandler {
 
 		try{
 			ensureLoggingConfigured();
-			
+
 			List<DflPlayer> players = dflPlayerService.findAll();
 			List<Map<Integer, DflPlayerScores>> playerScores = new ArrayList<>();
-			
+
 			for(int i = 1; i <= round; i++) {
 				playerScores.add(dflPlayerScoresService.getForRoundWithKey(i));
 			}
-			
+
 			calculateStandings(round, players, playerScores);
-			
+
 			dflPlayerService.close();
 			dflPlayerScoresService.close();
 			dflTeamPlayerService.close();
 			globalsService.close();
-			
+
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in ... ", ex);
 		}
 	}
-	
+
 	public List<DflCallumChambers> getMedalStandings() {
 		return medalStandings;
 	}
-	
+
 	private void calculateStandings(int round, List<DflPlayer> players, List<Map<Integer, DflPlayerScores>> playerScores) {
-		
+
 		Map<String, String> draftOrder = globalsService.getDraftOrder();
-		
+
 		for(DflPlayer player : players) {
 			int score = 0;
-			
+
 			DflTeamPlayer teamPlayer = dflTeamPlayerService.get(player.getPlayerId());
-			
+
 			if(teamPlayer != null) {
 				String teamCode = teamPlayer.getTeamCode();
 				int teamPlayerId = teamPlayer.getTeamPlayerId();
-				
+
 				for(Map<Integer, DflPlayerScores> roundScores : playerScores) {
 					if(roundScores.containsKey(player.getPlayerId())) {
 						score = score + roundScores.get(player.getPlayerId()).getScore();
 					}
 				}
-				
-				
+
 				DflCallumChambers callumChambersTotal = new DflCallumChambers();
 				callumChambersTotal.setRound(round);
 				callumChambersTotal.setPlayerId(player.getPlayerId());
 				callumChambersTotal.setTeamCode(teamCode);
-				callumChambersTotal.setDraftOrder(Integer.parseInt(draftOrder.get(teamCode)));
+				String draftOrderValue = draftOrder.get(teamCode);
+				if (draftOrderValue == null) {
+					loggerUtils.log("warn", "No draft order found for teamCode: {}", teamCode);
+					continue;
+				}
+				callumChambersTotal.setDraftOrder(Integer.parseInt(draftOrderValue));
 				callumChambersTotal.setTeamPlayerId(teamPlayerId);
 				callumChambersTotal.setTotalScore(score);
-				
+
 				medalStandings.add(callumChambersTotal);
 			}
 		}
-		
+
 		Collections.sort(medalStandings, Collections.reverseOrder());
 	}
 
-	public void report() {			
+	public void report() {
 		loggerUtils.log("info", "Callum Chambers top 5 for round");
-		for(int i = 0; i < 5; i++) {
+		for(int i = 0; i < Math.min(5, medalStandings.size()); i++) {
 			DflCallumChambers standing = medalStandings.get(i);
 			loggerUtils.log("info", "{}. {}, {}, {}, {} - {}",
-							i+1, standing.getPlayerId(), standing.getTeamCode(), standing.getDraftOrder(), 
+							i+1, standing.getPlayerId(), standing.getTeamCode(), standing.getDraftOrder(),
 							standing.getTeamPlayerId(), standing.getTotalScore());
 		}
 	}
-	
+
 	public static void main(String[] args) {
-		
+
 		Options options = new Options();
-		
+
 		Option roundOpt  = Option.builder("r").argName("round").hasArg().desc("round to run to").type(Number.class).required().build();
-		
+
 		options.addOption(roundOpt);
-		
+
 		try {
 			int round = 0;
-						
+
 			CommandLineParser parser = new DefaultParser();
 			CommandLine cli = parser.parse(options, args);
-			
+
 			round = ((Number)cli.getParsedOptionValue("r")).intValue();
 
 			CallumChambersHandler callumChambersHandler = new CallumChambersHandler();
 			callumChambersHandler.configureLogging("batch.name", "batch-logger", ("CallumChambersHandler_R" + round));
 			callumChambersHandler.execute(round);
-						
+
 			callumChambersHandler.report();
-			
+
 		} catch (ParseException ex) {
 			HelpFormatter formatter = new HelpFormatter();
 			formatter.printHelp( "adamGoodesHandler", options);

--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -381,7 +381,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 		List<Integer> ins = new ArrayList<>();
 		List<Integer> outs = new ArrayList<>();
 		List<Double> emgs = new ArrayList<>();
-		BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
 
 		loggerUtils.log("info", "Handling selections form file attachement");
 
@@ -471,6 +471,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 				}
 				loggerUtils.log("info", "Selection emergencies: {}", emgs);
 			}
+		}
 		}
 
 		Map<String, List<Integer>> insAndOuts = new HashMap<>();
@@ -694,11 +695,15 @@ public class EmailSelectionsHandler extends BaseHandler {
 			if (validationResult.isValid()) {
 				if (teamCode != null && !teamCode.equals("")) {
 					DflTeam team = dflTeamService.get(teamCode);
-					String teamTo = team.getCoachEmail();
-					loggerUtils.log("info", "Team email: {}", teamTo);
-					if (!to.toLowerCase().contains(teamTo.toLowerCase())) {
-						loggerUtils.log("info", "Adding team email");
-						message.addRecipients(Message.RecipientType.TO, InternetAddress.parse(teamTo));
+					if (team != null) {
+						String teamTo = team.getCoachEmail();
+						loggerUtils.log("info", "Team email: {}", teamTo);
+						if (!to.toLowerCase().contains(teamTo.toLowerCase())) {
+							loggerUtils.log("info", "Adding team email");
+							message.addRecipients(Message.RecipientType.TO, InternetAddress.parse(teamTo));
+						}
+					} else {
+						loggerUtils.log("warn", "No team found for teamCode: {}", teamCode);
 					}
 				}
 				loggerUtils.log("info", "Message is for SUCCESS");


### PR DESCRIPTION
## Summary
- Null-check `draftOrder.get(teamCode)` before `Integer.parseInt()` to prevent NPE when a team code has no draft order configured
- Use `Math.min(5, medalStandings.size())` in `report()` to prevent `IndexOutOfBoundsException` when fewer than 5 players have standings