### PR TITLE
Fix NPE in ValueComparator when map key is missing

### DIFF
--- a/src/main/java/net/dflmngr/handlers/Best22Handler.java
+++ b/src/main/java/net/dflmngr/handlers/Best22Handler.java
@@ -235,13 +235,18 @@ class ValueComparator<K, V extends Comparable<V>> implements Comparator<K>{
  
 	@Override
 	public int compare(K s1, K s2) {
-		int c = map.get(s1).compareTo(map.get(s2));
+		V v1 = map.get(s1);
+		V v2 = map.get(s2);
+		if (v1 == null || v2 == null) {
+			return 0;
+		}
+		int c = v1.compareTo(v2);
 		if(c > 0) {
 			return -1;
 		} else if(c < 0) {
 			return 1;
 		} else {
 			return 0;
-		}	
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Null-check map values before calling `compareTo()` in `ValueComparator.compare()` to prevent NPE if a key is not present in the backing map