### PR TITLE
Fix IndexOutOfBounds in MatthewAllenHandler vote calculation

### DIFF
--- a/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
+++ b/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
@@ -78,6 +78,10 @@ public class MatthewAllenHandler extends BaseHandler {
 		List<DflMatthewAllen> votes = new ArrayList<>();
 
 		for(int voteValue = 3; voteValue > 0; voteValue--) {
+			if (selectedPlayerScores.size() < 2) {
+				loggerUtils.log("warn", "Not enough player scores to assign {} votes, round={}, game={}", voteValue, round, game);
+				break;
+			}
 			DflPlayerScores playerScore = selectedPlayerScores.get(0);
 			DflPlayerScores playerScoreNext = selectedPlayerScores.get(1);
 


### PR DESCRIPTION
## Summary
- Guard the vote loop with a size check on `selectedPlayerScores` before calling `get(0)` and `get(1)`, preventing `IndexOutOfBoundsException` when fewer than 2 players have scores for a game