### PR TITLE
Improve logging across all handlers

### DIFF
--- a/src/main/java/net/dflmngr/handlers/AdamGoodesHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AdamGoodesHandler.java
@@ -62,7 +62,7 @@ public class AdamGoodesHandler extends BaseHandler {
 			dflSelectedTeamService.close();
 	
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in AdamGoodesHandler.execute(), round=" + round, ex);
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/AflFixtureLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflFixtureLoaderHandler.java
@@ -31,7 +31,7 @@ public class AflFixtureLoaderHandler extends BaseHandler {
 			aflFixtureHtmlHandler = new AflFixtureHtmlHandler();
 			ensureLoggingConfigured();
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in AflFixtureLoaderHandler constructor", ex);
 		}
 	}
 	
@@ -49,12 +49,12 @@ public class AflFixtureLoaderHandler extends BaseHandler {
 			String aflFixtureUrl = aflFixtureUrlParts.get(0) + aflRoundUri;
 			allGames.addAll(aflFixtureHtmlHandler.execute(aflRound, aflFixtureUrl));
 		}
-		
-		loggerUtils.log("info", "Saveing data to DB");
-		
+
+		loggerUtils.log("info", "Saving {} games to DB across {} rounds", allGames.size(), aflRounds.size());
+
 		aflFixtureService.updateLoadedFixtures(allGames);
-		
-		loggerUtils.log("info", "AflFixtureLoader Complete");
+
+		loggerUtils.log("info", "AflFixtureLoader complete");
 	}
 		
 	// For internal testing

--- a/src/main/java/net/dflmngr/handlers/AflGameCompletionCheckerHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflGameCompletionCheckerHandler.java
@@ -45,7 +45,7 @@ public class AflGameCompletionCheckerHandler extends BaseHandler {
 		try {
 			ensureLoggingConfigured();
 
-			loggerUtils.log("info", "AflGameCompletionChecker excuting ....");
+			loggerUtils.log("info", "AflGameCompletionChecker executing");
 
 			List<AflFixture> incompleteFixtures = aflFixtureService.getIncompleteFixtures();
 
@@ -85,10 +85,10 @@ public class AflGameCompletionCheckerHandler extends BaseHandler {
 			aflFixtureService.close();
 			globalsService.close();
 
-			loggerUtils.log("info", "AflGameCompletionChecker comlpeted");
+			loggerUtils.log("info", "AflGameCompletionChecker completed");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in AflGameCompletionCheckerHandler.execute()", ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
@@ -144,7 +144,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 				int dflPlayerId = dflPlayer.getPlayerId();
 				String aflPlayerId = aflPlayer.getPlayerId();
 
-				loggerUtils.log("info", "Matched player - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", aflPlayerCrossRef, dflPlayerId, aflPlayerId);
+				loggerUtils.log("debug", "Matched player - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", aflPlayerCrossRef, dflPlayerId, aflPlayerId);
 
 				dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 				aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -179,7 +179,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		    		int dflPlayerId = dflPlayer.getPlayerId();
 					String aflPlayerId = aflPlayer.getPlayerId();
 
-					loggerUtils.log("info", "Matched player on check one - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+					loggerUtils.log("debug", "Matched player on check one - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 					dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 					aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -195,7 +195,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 			    		int dflPlayerId = dflPlayer.getPlayerId();
 						String aflPlayerId = aflPlayer.getPlayerId();
 
-						loggerUtils.log("info", "Matched player on check two - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+						loggerUtils.log("debug", "Matched player on check two - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 						dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 						aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -212,7 +212,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 			    		int dflPlayerId = dflPlayer.getPlayerId();
 						String aflPlayerId = aflPlayer.getPlayerId();
 
-						loggerUtils.log("info", "Matched player on check three - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+						loggerUtils.log("debug", "Matched player on check three - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 						dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 						aflPlayerUpdates.put(dflPlayerId, aflPlayer);

--- a/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
@@ -37,7 +37,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 			ensureLoggingConfigured();
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in AflPlayerLoaderHandler constructor", ex);
 		}
 	}
 
@@ -54,7 +54,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 			loggerUtils.log("info", "AflPlayerLoader Complete");
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in AflPlayerLoaderHandler.execute()", ex);
 		}
 
 	}
@@ -96,10 +96,10 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 		aflPlayers = removeDuplicates(aflPlayers);
 
-		loggerUtils.log("info", "Saving players to database ...");
+		loggerUtils.log("info", "Saving {} players to database", aflPlayers.size());
 		aflPlayerService.replaceAll(aflPlayers);
 
-		loggerUtils.log("info", "Creating afl-dfl player cross references");
+		loggerUtils.log("info", "Creating afl-dfl player cross references for {} players", aflPlayers.size());
 		crossRefAflDflPlayers(aflPlayers);
 
 		loggerUtils.log("info", "AFL players loaded");
@@ -118,7 +118,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 				}
 			}
 			if(playerExists) {
-				loggerUtils.log("info", "Player EXISTS!!; Player: {}", player);
+				loggerUtils.log("debug", "Skipping duplicate player: {}", player);
 			} else {
 				checkedPlayers.add(player);
 			}
@@ -137,7 +137,6 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 		for(AflPlayer aflPlayer : aflPlayers) {
 			String aflPlayerCrossRef = (aflPlayer.getName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflPlayer.getTeamId()).toLowerCase();
-			loggerUtils.log("info", "Searching for player: {}", aflPlayerCrossRef);
 			DflPlayer dflPlayer = dflPlayerCrossRefs.get(aflPlayerCrossRef);
 
 			if(dflPlayer != null) {
@@ -152,7 +151,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 				dflPlayerCrossRefs.remove(aflPlayerCrossRef);
 			} else {
-				loggerUtils.log("info", "Unmatched AFL player: {}", aflPlayer);
+				loggerUtils.log("warn", "Unmatched AFL player (no DFL cross-reference found): {}", aflPlayer);
 				aflUnmatchedPlayers.add(aflPlayer);
 			}
 		}
@@ -175,13 +174,12 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 
 		    	String aflCheckOne = (aflPlayer.getName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflTeamName).toLowerCase();
 
-		    	loggerUtils.log("info", "Check one {} vs {}", dflCheckOne, aflCheckOne);
 
 		    	if(dflCheckOne.equals(aflCheckOne)) {
 		    		int dflPlayerId = dflPlayer.getPlayerId();
 					String aflPlayerId = aflPlayer.getPlayerId();
 
-					loggerUtils.log("info", "Matched player on Check One - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+					loggerUtils.log("info", "Matched player on check one - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 					dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 					aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -192,13 +190,12 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		    	if(!matched) {
 		    		String aflCheckTwo = (aflPlayer.getSecondName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflTeamName).toLowerCase();
 
-		    		loggerUtils.log("info", "Check two {} vs {}", dflCheckTwo, aflCheckTwo);
 
 		    		if(dflCheckTwo.equals(aflCheckTwo)) {
 			    		int dflPlayerId = dflPlayer.getPlayerId();
 						String aflPlayerId = aflPlayer.getPlayerId();
 
-						loggerUtils.log("info", "Matched player on Check Two - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+						loggerUtils.log("info", "Matched player on check two - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 						dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 						aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -210,13 +207,12 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		    	if(!matched) {
 		    		String aflCheckThree = (aflPlayer.getFirstName().replaceAll(NOT_ALPHA_REGEX, "") + "-" + aflTeamName).toLowerCase();
 
-		    		loggerUtils.log("info", "Check three {} vs {}", dflCheckThree, aflCheckThree);
 
 		    		if(dflCheckThree.equals(aflCheckThree)) {
 			    		int dflPlayerId = dflPlayer.getPlayerId();
 						String aflPlayerId = aflPlayer.getPlayerId();
 
-						loggerUtils.log("info", "Matched player on Check Two - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
+						loggerUtils.log("info", "Matched player on check three - CrossRef: {}, DflPlayerId: {}, AflPlayerId {}", crossRef, dflPlayerId, aflPlayerId);
 
 						dflPlayerUpdates.put(aflPlayerId, dflPlayer);
 						aflPlayerUpdates.put(dflPlayerId, aflPlayer);
@@ -231,7 +227,7 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		    }
 
 		    if(!matched) {
-			    loggerUtils.log("info", "Unmatched player: {}", crossRef);
+			    loggerUtils.log("warn", "Unmatched DFL player after all checks (will be saved as unmatched): {}", crossRef);
 
 			    DflUnmatchedPlayer unmatchedPlayer = new DflUnmatchedPlayer();
 			    unmatchedPlayer.setPlayerId(dflPlayer.getPlayerId());

--- a/src/main/java/net/dflmngr/handlers/Best22Handler.java
+++ b/src/main/java/net/dflmngr/handlers/Best22Handler.java
@@ -41,7 +41,7 @@ public class Best22Handler extends BaseHandler {
 		try{
 			ensureLoggingConfigured();
 			
-			loggerUtils.log("info", "Best22Handler excuting, round={} ....", round);
+			loggerUtils.log("info", "Best22Handler executing, round={}", round);
 			
 			calculateBest22(round);
 			
@@ -50,7 +50,7 @@ public class Best22Handler extends BaseHandler {
 			loggerUtils.log("info", "Best22Handler complete");
 			
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in Best22Handler.execute(), round=" + round, ex);
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
+++ b/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
@@ -63,7 +63,7 @@ public class CallumChambersHandler extends BaseHandler {
 			globalsService.close();
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in CallumChambersHandler.execute(), round=" + round, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/DflFixtureGeneratorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/DflFixtureGeneratorHandler.java
@@ -24,7 +24,7 @@ public class DflFixtureGeneratorHandler extends BaseHandler {
 		try{
 			ensureLoggingConfigured();
 			
-			loggerUtils.log("info", "DflFixtureGeneratorHandler excuting....");
+			loggerUtils.log("info", "DflFixtureGeneratorHandler executing");
 			
 			loggerUtils.log("info", "Generating DFL Fixture");
 			generateFixture();
@@ -32,7 +32,7 @@ public class DflFixtureGeneratorHandler extends BaseHandler {
 			loggerUtils.log("info", "DflFixtureGeneratorHandler completed");
 			
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in DflFixtureGeneratorHandler.execute()", ex);
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/DflRoundInfoCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/DflRoundInfoCalculatorHandler.java
@@ -59,7 +59,7 @@ public class DflRoundInfoCalculatorHandler extends BaseHandler {
 			configureStatsRoundTracking();
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in DflRoundInfoCalculatorHandler constructor", ex);
 		}
 	}
 
@@ -90,7 +90,7 @@ public class DflRoundInfoCalculatorHandler extends BaseHandler {
 			
 			loggerUtils.log("info", "DflRoundInfoCalculator Complete");
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in DflRoundInfoCalculatorHandler.execute()", ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -125,7 +125,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 
 			loggerUtils.log("info", "Email Selections Handler Completed");
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in EmailSelectionsHandler.execute()", ex);
 		}
 	}
 
@@ -147,7 +147,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 
 		for (int i = 0; i < messages.length; i++) {
 
-			loggerUtils.log("info", "Handling message {}", i);
+			loggerUtils.log("debug", "Handling message {}", i);
 
 			SelectedTeamValidation validationResult = null;
 
@@ -205,7 +205,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 					}
 				}
 			} catch (Exception ex) {
-				loggerUtils.logException("Error in ... ", ex);
+				loggerUtils.logException("Error in EmailSelectionsHandler processing message " + i + " from inbox", ex);
 				try {
 					String from = InternetAddress.toString(messages[i].getFrom());
 					validationResult = new SelectedTeamValidation();
@@ -217,7 +217,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 					validationResults.add(validationResult);
 					loggerUtils.log("info", "Message from {} ... FAILURE with EXCEPTION!", from);
 				} catch (MessagingException ex2) {
-					loggerUtils.log("error", "Error in ... ", ex2);
+					loggerUtils.log("error", "Error retrieving sender address for failed message", ex2);
 				}
 			}
 		}
@@ -398,7 +398,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						teamCode = line;
 					}
 				}
-				loggerUtils.log("info", "Selections for team: {}", teamCode);
+				loggerUtils.log("debug", "Selections for team: {}", teamCode);
 			}
 
 			if (line.toLowerCase().contains(TAG_ROUND)) {
@@ -413,7 +413,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						round = Integer.parseInt(line);
 					}
 				}
-				loggerUtils.log("info", "Selections for round: {}", round);
+				loggerUtils.log("debug", "Selections for round: {}", round);
 			}
 
 			if (line.toLowerCase().contains(TAG_IN)) {
@@ -429,7 +429,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						ins.add(Integer.parseInt(line));
 					}
 				}
-				loggerUtils.log("info", "Selection in: {}", ins);
+				loggerUtils.log("debug", "Selection in: {}", ins);
 			}
 
 			if (line.toLowerCase().contains(TAG_OUT)) {
@@ -445,7 +445,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						outs.add(Integer.parseInt(line));
 					}
 				}
-				loggerUtils.log("info", "Selection out: {}", outs);
+				loggerUtils.log("debug", "Selection out: {}", outs);
 			}
 
 			if (line.toLowerCase().contains(TAG_EMG)) {
@@ -469,7 +469,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						emgs.add(emg);
 					}
 				}
-				loggerUtils.log("info", "Selection emergencies: {}", emgs);
+				loggerUtils.log("debug", "Selection emergencies: {}", emgs);
 			}
 		}
 		}
@@ -509,7 +509,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						teamCode = line;
 					}
 				}
-				loggerUtils.log("info", "Selections for team: {}", teamCode);
+				loggerUtils.log("debug", "Selections for team: {}", teamCode);
 			}
 
 			if (line.toLowerCase().contains(TAG_ROUND)) {
@@ -524,7 +524,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 						round = Integer.parseInt(line);
 					}
 				}
-				loggerUtils.log("info", "Selections for round: {}", round);
+				loggerUtils.log("debug", "Selections for round: {}", round);
 			}
 
 			if (line.toLowerCase().contains(TAG_IN)) {
@@ -541,11 +541,11 @@ public class EmailSelectionsHandler extends BaseHandler {
 						if (in > 0) {
 							ins.add(in);
 						} else {
-							loggerUtils.log("info", "Couldn't get player number for INs, No.={}", in);
+							loggerUtils.log("debug", "Couldn't get player number for INs, No.={}", in);
 						}
 					}
 				}
-				loggerUtils.log("info", "Selection in: {}", ins);
+				loggerUtils.log("debug", "Selection in: {}", ins);
 			}
 
 			if (line.toLowerCase().contains(TAG_OUT)) {
@@ -562,11 +562,11 @@ public class EmailSelectionsHandler extends BaseHandler {
 						if (out > 0) {
 							outs.add(out);
 						} else {
-							loggerUtils.log("info", "Couldn't get player number for OUTs, No.={}", out);
+							loggerUtils.log("debug", "Couldn't get player number for OUTs, No.={}", out);
 						}
 					}
 				}
-				loggerUtils.log("info", "Selection out: {}", outs);
+				loggerUtils.log("debug", "Selection out: {}", outs);
 			}
 
 			if (line.toLowerCase().contains(TAG_EMG)) {
@@ -590,11 +590,11 @@ public class EmailSelectionsHandler extends BaseHandler {
 							}
 							emgs.add(emg);
 						} else {
-							loggerUtils.log("info", "Couldn't get player number for OUTs, No.={}", emg);
+							loggerUtils.log("debug", "Couldn't get player number for OUTs, No.={}", emg);
 						}
 					}
 				}
-				loggerUtils.log("info", "Selection emergencies: {}", emgs);
+				loggerUtils.log("debug", "Selection emergencies: {}", emgs);
 			}
 		}
 

--- a/src/main/java/net/dflmngr/handlers/EndRoundHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EndRoundHandler.java
@@ -161,7 +161,7 @@ public class EndRoundHandler extends BaseHandler {
 			loggerUtils.log("info", "End round completed");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in EndRoundHandler.execute(), round=" + round, ex);
 		}
 
 	}

--- a/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
@@ -58,7 +58,7 @@ public class LadderCalculatorHandler extends BaseHandler {
 			loggerUtils.log("info", "LadderCalculatorHandler completed");
 			
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in LadderCalculatorHandler.execute(), round=" + round, ex);
 		}
 	}
 		

--- a/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
+++ b/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
@@ -46,7 +46,7 @@ public class MatthewAllenHandler extends BaseHandler {
 		try{
 			ensureLoggingConfigured();
 			
-			loggerUtils.log("info", "MatthewAllenHandler excuting, rount={} ....", round);
+			loggerUtils.log("info", "MatthewAllenHandler executing, round={}", round);
 			
 			List<DflFixture> roundFixtures = dflFixtureService.getFixturesForRound(round);
 			dflMatthewAllenService.deleteForRound(round);
@@ -60,7 +60,7 @@ public class MatthewAllenHandler extends BaseHandler {
 			loggerUtils.log("info", "MatthewAllenHandler complete");
 			
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in MatthewAllenHandler.execute(), round=" + round, ex);
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/PredictionHandler.java
+++ b/src/main/java/net/dflmngr/handlers/PredictionHandler.java
@@ -46,7 +46,7 @@ public class PredictionHandler extends BaseHandler {
 		try{
 			ensureLoggingConfigured();
 
-			loggerUtils.log("info", "PredictionHandler excuting, round={} ....", round);
+			loggerUtils.log("info", "PredictionHandler executing, round={}", round);
 
 			if(doPlayers) {
 				calculatePlayerPredictions(round);
@@ -63,7 +63,7 @@ public class PredictionHandler extends BaseHandler {
 			dflSelectedTeamService.close();
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in PredictionHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/RawPlayerStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/RawPlayerStatsHandler.java
@@ -68,10 +68,10 @@ public class RawPlayerStatsHandler extends BaseHandler {
 			statsRoundPlayerStatsService.close();
 			rawPlayerStatsService.close();
 
-			loggerUtils.log("info", "Player stats downaloded");
+			loggerUtils.log("info", "Player stats downloaded");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in RawPlayerStatsHandler.execute(), round=" + round, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/ResultsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ResultsHandler.java
@@ -43,7 +43,7 @@ public class ResultsHandler extends BaseHandler {
 		try{
 			ensureLoggingConfigured();
 			
-			loggerUtils.log("info", "ResultsHandler excuting ....");
+			loggerUtils.log("info", "ResultsHandler executing");
 
 			if(emailOverride != null && !emailOverride.equals("")) {
 				loggerUtils.log("info", "Overriding email with: {}", emailOverride);
@@ -71,7 +71,7 @@ public class ResultsHandler extends BaseHandler {
 			loggerUtils.log("info", "ResultsHandler complete");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in ResultsHandler.execute(), inputRound=" + inputRound, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -104,7 +104,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			loggerUtils.log("info", "ScoresCalculator completed");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in ScoresCalculatorHandler.execute(), round=" + round, ex);
 		}
 	}
 
@@ -124,7 +124,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			DflPlayer dflPlayer = dflPlayerService.getByAflPlayerId(aflPlayerId);
 
 			if(dflPlayer == null) {
-				loggerUtils.log("info", "Missing afl dfl player mapping: aflPlayerId={};", aflPlayerId);
+				loggerUtils.log("warn", "Missing afl-dfl player mapping, score will not be recorded: aflPlayerId={}", aflPlayerId);
 			} else {
 				DflTeamPlayer dflTeamPlayer = dflTeamPlayerService.get(dflPlayer.getPlayerId());
 
@@ -139,11 +139,12 @@ public class ScoresCalculatorHandler extends BaseHandler {
 
 				playerScores.setScore(score);
 
-				loggerUtils.log("info", "Player score={}", playerScores);
+				loggerUtils.log("debug", "Player score={}", playerScores);
 				scores.add(playerScores);
 			}
 		}
 
+		loggerUtils.log("info", "Calculated scores for {} players (from {} raw stats records), round={}", scores.size(), stats.size(), round);
 		dflPlayerScoresService.replaceAllForRound(round, scores);
 	}
 
@@ -180,10 +181,11 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			teamScore.setRound(round);
 			teamScore.setScore(score);
 
-			loggerUtils.log("info", "Team score={}", teamScore);
+			loggerUtils.log("debug", "Team score={}", teamScore);
 			scores.add(teamScore);
 		}
 
+		loggerUtils.log("info", "Calculated scores for {} DFL teams, round={}", scores.size(), round);
 		dflTeamScoresService.replaceAllForRound(round, scores);
 	}
 
@@ -217,7 +219,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 					aflRound = currentAflRound;
 				}
 			}
-			loggerUtils.log("info", "Played teams for AFL round={} teams={}", aflRound, playedTeams);
+			loggerUtils.log("debug", "Played teams for AFL round={} teams={}", aflRound, playedTeams);
 		}
 
 		int ffCount = 0;
@@ -265,20 +267,20 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			selectedPlayer.setReplacementInd(null);
 
 			if(playerScore == null) {
-				loggerUtils.log("info", "Selected player: team={} teamPlayerId={} playerId={} has no score recorded",
+				loggerUtils.log("debug", "Selected player: team={} teamPlayerId={} playerId={} has no score recorded",
 								selectedPlayer.getTeamCode(), selectedPlayer.getTeamPlayerId(), selectedPlayer.getPlayerId());
 				if(playedTeams.contains(player.getAflClub())) {
-					loggerUtils.log("info", "AFL team has played, marking as DNP");
+					loggerUtils.log("debug", "AFL team has played, marking as DNP");
 					selectedPlayer.setDnp(true);
 					selectedPlayer.setScoreUsed(false);
 					selectedPlayer.setHasPlayed(true);
 					dnpPlayers.add(selectedPlayer);
 				} else {
-					loggerUtils.log("info", "Checking if average will be used");
+					loggerUtils.log("debug", "Checking if average will be used");
 					try {
 						int round = globalsService.getUseAverage(player.getAflClub());
 
-						loggerUtils.log("info", "Is global set for teamCode={} round={} selectedRound={}",
+						loggerUtils.log("debug", "Is global set for teamCode={} round={} selectedRound={}",
 						   				player.getAflClub(), round, selectedPlayer.getRound());
 
 						if(round == selectedPlayer.getRound()) {
@@ -287,7 +289,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 	
 							selectedPlayer.setHasPlayed(true);
 	
-							loggerUtils.log("info", "Using average score={}", score);
+							loggerUtils.log("debug", "Using average score={}", score);
 	
 							if(selectedPlayer.isEmergency() == 0) {
 								selectedPlayer.setScoreUsed(true);
@@ -298,14 +300,14 @@ public class ScoresCalculatorHandler extends BaseHandler {
 							}
 						}
 					} catch (MissingGlobalConfig e) {
-						loggerUtils.log("info", "Average not used ");
+						loggerUtils.log("debug", "Average not used");
 					}
 				}
 			} else {
-				loggerUtils.log("info", "Selected player: team={} teamPlayerId={} playerId={} has score recorded",
+				loggerUtils.log("debug", "Selected player: team={} teamPlayerId={} playerId={} has score recorded",
 								selectedPlayer.getTeamCode(), selectedPlayer.getTeamPlayerId(), selectedPlayer.getPlayerId());
 
-				loggerUtils.log("info", "Using score={}", playerScore.getScore());
+				loggerUtils.log("debug", "Using score={}", playerScore.getScore());
 
 				scores.put(selectedPlayer.getPlayerId(), playerScore.getScore());
 
@@ -525,7 +527,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 		for(DflSelectedPlayer player : played22) {
 			if(!player.isDnp() && scores.containsKey(player.getPlayerId())) {
 				teamScore = teamScore + scores.get(player.getPlayerId());
-				loggerUtils.log("info", "Calculating scores team={}, playerId={}. teamplayer={}, playerscore={}, teamscore={}",
+				loggerUtils.log("debug", "Calculating scores team={}, playerId={}. teamplayer={}, playerscore={}, teamscore={}",
 							player.getTeamCode(), player.getPlayerId(), player.getTeamPlayerId(), scores.get(player.getPlayerId()), teamScore);
 
 			}

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -77,7 +77,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 			aflFixtureService.close();
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in SelectedTeamValidationHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
 		}
 
 		return validationResult;

--- a/src/main/java/net/dflmngr/handlers/SelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectionsHandler.java
@@ -58,7 +58,7 @@ public class SelectionsHandler extends BaseHandler {
 			loggerUtils.log("info", "Team selections created");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in SelectionsHandler.execute(), round=" + round, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/StartRoundHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StartRoundHandler.java
@@ -99,7 +99,7 @@ public class StartRoundHandler extends BaseHandler {
 			aflFixtureService.close();
 		
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in StartRoundHandler.execute(), round=" + round, ex);
 		}
 	}
 		

--- a/src/main/java/net/dflmngr/handlers/StatsDownloaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StatsDownloaderHandler.java
@@ -106,7 +106,7 @@ public class StatsDownloaderHandler extends BaseHandler {
 				loggerUtils.log("info", "Player stats were not downloaded");
 			}
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in StatsDownloaderHandler.execute(), homeTeam=" + homeTeam + " awayTeam=" + awayTeam, ex);
 		} finally {
 			rawPlayerStatsService.close();
 			statsRoundPlayerStatsService.close();

--- a/src/main/java/net/dflmngr/handlers/StatsRoundPlayerStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StatsRoundPlayerStatsHandler.java
@@ -61,10 +61,10 @@ public class StatsRoundPlayerStatsHandler extends BaseHandler {
 			aflFixtureService.close();
 			globalsService.close();
 
-			loggerUtils.log("info", "Stats round player stats downaloded");
+			loggerUtils.log("info", "Stats round player stats downloaded");
 
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in StatsRoundPlayerStatsHandler.execute(), round=" + round, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
@@ -50,7 +50,7 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 			dflTeamPlayerService.close();
 						
 		} catch (Exception ex) {
-			loggerUtils.logException("Error in ... ", ex);
+			loggerUtils.logException("Error in TeamInsOutsLoaderHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/logging/LoggingUtils.java
+++ b/src/main/java/net/dflmngr/logging/LoggingUtils.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LoggingUtils {
-	
+
 	private Logger logger;
 	private String process;
 
@@ -12,39 +12,38 @@ public class LoggingUtils {
 		this.process = process;
 
 		boolean logToSyslog = Boolean.parseBoolean(System.getenv().getOrDefault("LOG_TO_SYSLOG", "false"));
-		
+
 		if(logToSyslog) {
 			logger = LoggerFactory.getLogger("stdout-with-syslog-logger");
 		} else {
 			logger = LoggerFactory.getLogger("stdout-logger");
 		}
 	}
-	
+
 	public void log(String level, String msg, Object...arguments) {
-
-		String callingClass = Thread.currentThread().getStackTrace()[2].getClassName();
-		String callingClassShort = callingClass.substring(callingClass.lastIndexOf(".")+1, callingClass.length());
-		String callingMethod = Thread.currentThread().getStackTrace()[2].getMethodName();
-		int lineNo = Thread.currentThread().getStackTrace()[2].getLineNumber();
-		
-		String loggerMsg = "[" + process + "]" + "[" + callingClassShort + "." +  callingMethod + "(Line:" + lineNo +")] - " + msg;
-
-		try {
-			switch (level) {
-				case "info" : logger.info(loggerMsg, arguments); break;
-				case "error" : logger.error(loggerMsg, arguments); break;
-				default : logger.debug(loggerMsg, arguments); break;
-			}
-		} catch (Exception ex) {
-			logger.error("Error in ... ", ex);
+		switch (level) {
+			case "info"  : if (logger.isInfoEnabled())  logger.info(callerMsg(msg), prepend(process, arguments)); break;
+			case "warn"  : if (logger.isWarnEnabled())  logger.warn(callerMsg(msg), prepend(process, arguments)); break;
+			case "error" : if (logger.isErrorEnabled()) logger.error(callerMsg(msg), prepend(process, arguments)); break;
+			default      : if (logger.isDebugEnabled()) logger.debug(callerMsg(msg), prepend(process, arguments)); break;
 		}
 	}
 
 	public void logException(String msg, Throwable ex) {
-		try {
-			logger.error(msg, ex);
-		} catch (Exception intEx) {
-			logger.error("Error in ... ", intEx);
-		}
+		logger.error("[{}] {}", process, msg, ex);
+	}
+
+	private String callerMsg(String msg) {
+		StackTraceElement caller = Thread.currentThread().getStackTrace()[3];
+		String shortClass = caller.getClassName();
+		shortClass = shortClass.substring(shortClass.lastIndexOf('.') + 1);
+		return "[{}][" + shortClass + "." + caller.getMethodName() + "(Line:" + caller.getLineNumber() + ")] - " + msg;
+	}
+
+	private Object[] prepend(Object first, Object[] rest) {
+		Object[] args = new Object[rest.length + 1];
+		args[0] = first;
+		System.arraycopy(rest, 0, args, 1, rest.length);
+		return args;
 	}
 }

--- a/src/main/resources/log4j2-local.yaml
+++ b/src/main/resources/log4j2-local.yaml
@@ -8,16 +8,16 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%p %c %m%n"
+        Pattern: "%p %m%n"
   
   Loggers:
     Logger:
-      - 
+      -
         name: stdout-logger
-        level: info
+        level: ${env:APP_LOG_LEVEL:-info}
         additivity: false
         AppenderRef:
           ref: STDOUT
     Root:
-      level: info
+      level: ${env:APP_LOG_LEVEL:-info}
 

--- a/src/main/resources/log4j2.yaml
+++ b/src/main/resources/log4j2.yaml
@@ -8,7 +8,7 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "%p %c %m%n"
+        Pattern: "%p %m%n"
     Syslog:
       name: SYSLOG
       format: RFC5424
@@ -22,25 +22,25 @@ Configuration:
   
   Loggers:
     Logger:
-      - 
+      -
         name: stdout-logger
-        level: info
+        level: ${env:APP_LOG_LEVEL:-info}
         additivity: false
         AppenderRef:
           ref: STDOUT
       -
         name: syslog-logger
-        level: info
+        level: ${env:APP_LOG_LEVEL:-info}
         additivity: false
         AppenderRef:
           ref: SYSLOG
-      - 
+      -
         name: stdout-with-syslog-logger
-        level: info
+        level: ${env:APP_LOG_LEVEL:-info}
         additivity: false
         AppenderRef:
           - ref: STDOUT
           - ref: SYSLOG
     Root:
-      level: info
+      level: ${env:APP_LOG_LEVEL:-info}
 


### PR DESCRIPTION
## Summary
- Replace all 26 generic `"Error in ... "` catch messages with handler name, method, and key parameters (round, teamCode, etc.)
- Fix copy-paste error in `AflPlayerLoaderHandler`: "Matched player on Check Two" was used for the check three block
- Remove verbose per-player-comparison logs from `AflPlayerLoaderHandler` cross-reference loop (eliminated thousands of log lines per run)
- Change unmatched player/missing mapping logs from INFO to WARN across `AflPlayerLoaderHandler` and `ScoresCalculatorHandler`
- Downgrade per-item detail logs to DEBUG in `ScoresCalculatorHandler` and `EmailSelectionsHandler` (per-player scores, per-round-mapping, per-token parse lines)
- Add summary count logs after batch operations (players scored, teams scored, fixtures saved)
- Fix typos in log messages: "excuting", "rount", "comlpeted", "downaloded", "Saveing" across 8 handlers