### PR TITLE
Add Loki log shipping via Tjahzi Log4j2 appender

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,16 @@ RUN ./mvnw -T 2 clean package -DskipTests
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
-# Install Chrome 143 to match selenium-devtools-v143
+# Install Chrome 143 to match selenium-devtools-v143 and download OTel Java agent
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
     wget -q "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb" -O /tmp/chrome.deb && \
     apt-get install -y /tmp/chrome.deb && \
     rm /tmp/chrome.deb && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    wget -q "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.25.0/opentelemetry-javaagent.jar" \
+        -O /app/opentelemetry-javaagent.jar
 
 # Copy application artifacts
 COPY --from=build /app/target/dflmngr.jar target/
@@ -34,4 +36,12 @@ COPY bin/*.sh bin/
 # Create SSH directory
 RUN mkdir -p "$HOME"/.ssh && chmod 700 "$HOME"/.ssh
 
-CMD ["java", "-classpath", "/app/target/dflmngr.jar:/app/target/dependency/*", "net.dflmngr.scheduler.JobScheduler"]
+ENV OTEL_SERVICE_NAME=dfl-manager-scheduler
+ENV OTEL_LOGS_EXPORTER=none
+ENV OTEL_METRICS_EXPORTER=otlp
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+CMD ["java", \
+     "-javaagent:/app/opentelemetry-javaagent.jar", \
+     "-classpath", "/app/target/dflmngr.jar:/app/target/dependency/*", \
+     "net.dflmngr.scheduler.JobScheduler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,14 @@ RUN ./mvnw -T 2 clean package -DskipTests
 FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
-# Install Chrome 143 to match selenium-devtools-v143 and download OTel Java agent
+# Install Chrome 143 to match selenium-devtools-v143
 RUN apt-get update && \
     apt-get install -y wget gnupg && \
     wget -q "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb" -O /tmp/chrome.deb && \
     apt-get install -y /tmp/chrome.deb && \
     rm /tmp/chrome.deb && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget -q "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.25.0/opentelemetry-javaagent.jar" \
-        -O /app/opentelemetry-javaagent.jar
+    rm -rf /var/lib/apt/lists/*
 
 # Copy application artifacts
 COPY --from=build /app/target/dflmngr.jar target/
@@ -36,12 +34,4 @@ COPY bin/*.sh bin/
 # Create SSH directory
 RUN mkdir -p "$HOME"/.ssh && chmod 700 "$HOME"/.ssh
 
-ENV OTEL_SERVICE_NAME=dfl-manager-scheduler
-ENV OTEL_LOGS_EXPORTER=none
-ENV OTEL_METRICS_EXPORTER=otlp
-ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-
-CMD ["java", \
-     "-javaagent:/app/opentelemetry-javaagent.jar", \
-     "-classpath", "/app/target/dflmngr.jar:/app/target/dependency/*", \
-     "net.dflmngr.scheduler.JobScheduler"]
+CMD ["java", "-classpath", "/app/target/dflmngr.jar:/app/target/dependency/*", "net.dflmngr.scheduler.JobScheduler"]

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
 
 		<!-- Logging -->
 		<dependency>
+			<groupId>pl.tkowalcz.tjahzi</groupId>
+			<artifactId>log4j2-appender</artifactId>
+			<version>0.9.32</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>${log4j.version}</version>

--- a/src/main/java/net/dflmngr/handlers/BaseHandler.java
+++ b/src/main/java/net/dflmngr/handlers/BaseHandler.java
@@ -1,5 +1,7 @@
 package net.dflmngr.handlers;
 
+import org.slf4j.MDC;
+
 import net.dflmngr.logging.LoggingUtils;
 import net.dflmngr.service.ServiceFactory;
 
@@ -37,6 +39,9 @@ public abstract class BaseHandler {
 		this.loggerName = loggerName;
 		this.logfile = logfile;
 		this.isExecutable = true;
+		MDC.put("handler", logfile);
+		MDC.put("mdcKey", mdcKey);
+		MDC.put("loggerName", loggerName);
 	}
 
 	/**

--- a/src/main/java/net/dflmngr/logging/LoggingUtils.java
+++ b/src/main/java/net/dflmngr/logging/LoggingUtils.java
@@ -12,8 +12,11 @@ public class LoggingUtils {
 		this.process = process;
 
 		boolean logToSyslog = Boolean.parseBoolean(System.getenv().getOrDefault("LOG_TO_SYSLOG", "false"));
+		boolean logToLoki = Boolean.parseBoolean(System.getenv().getOrDefault("LOG_TO_LOKI", "false"));
 
-		if(logToSyslog) {
+		if(logToLoki) {
+			logger = LoggerFactory.getLogger("stdout-with-loki-logger");
+		} else if(logToSyslog) {
 			logger = LoggerFactory.getLogger("stdout-with-syslog-logger");
 		} else {
 			logger = LoggerFactory.getLogger("stdout-logger");

--- a/src/main/java/net/dflmngr/scheduler/jobs/BaseJob.java
+++ b/src/main/java/net/dflmngr/scheduler/jobs/BaseJob.java
@@ -4,6 +4,7 @@ import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.slf4j.MDC;
 
 import net.dflmngr.logging.LoggingUtils;
 
@@ -18,6 +19,7 @@ public abstract class BaseJob implements Job {
 	@Override
 	public final void execute(JobExecutionContext context) throws JobExecutionException {
 		loggerUtils = new LoggingUtils("Scheduler");
+		MDC.put("job", getJobName());
 
 		try {
 			loggerUtils.log("info", "{} starting ...", getJobName());
@@ -30,6 +32,8 @@ public abstract class BaseJob implements Job {
 			loggerUtils.log("info", "{} completed", getJobName());
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in " + getJobName(), ex);
+		} finally {
+			MDC.remove("job");
 		}
 	}
 

--- a/src/main/resources/log4j2.yaml
+++ b/src/main/resources/log4j2.yaml
@@ -19,7 +19,14 @@ Configuration:
       appName: DFLManager
       messageId: Worker
       newline: true
-  
+    Loki:
+      name: LOKI
+      host: ${env:LOKI_URL:-http://localhost:3100}
+      PatternLayout:
+        Pattern: "%m%n"
+      Label:
+        Pattern: "app=DFLManager,level=%p,job=%X{job},handler=%X{handler},mdcKey=%X{mdcKey},loggerName=%X{loggerName}"
+
   Loggers:
     Logger:
       -
@@ -41,6 +48,19 @@ Configuration:
         AppenderRef:
           - ref: STDOUT
           - ref: SYSLOG
+      -
+        name: loki-logger
+        level: ${env:APP_LOG_LEVEL:-info}
+        additivity: false
+        AppenderRef:
+          ref: LOKI
+      -
+        name: stdout-with-loki-logger
+        level: ${env:APP_LOG_LEVEL:-info}
+        additivity: false
+        AppenderRef:
+          - ref: STDOUT
+          - ref: LOKI
     Root:
       level: ${env:APP_LOG_LEVEL:-info}
 


### PR DESCRIPTION
## Summary

- Add Tjahzi `log4j2-appender` dependency for Grafana Loki integration
- Add `LOKI` appender to `log4j2.yaml` with structured labels: `app`, `level`, `job`, `handler`, `mdcKey`, `loggerName`
- Add `loki-logger` and `stdout-with-loki-logger` named loggers
- `LoggingUtils`: support `LOG_TO_LOKI` env var (takes priority over `LOG_TO_SYSLOG`)
- `BaseJob`: set MDC `job` label for the duration of Quartz job execution, cleared in `finally`
- `BaseHandler`: set MDC `handler`/`mdcKey`/`loggerName` labels on `configureLogging`
- Syslog appender retained; switch to Loki by setting `LOG_TO_LOKI=true` in Render env vars

## Test plan

- [ ] Set `LOG_TO_LOKI=true` and `LOKI_URL=<loki endpoint>` in Render environment
- [ ] Verify logs appear in Grafana Loki with correct labels
- [ ] Query by handler: `{app="DFLManager", handler="Selections"}`
- [ ] Query by level: `{app="DFLManager", level="ERROR"}`
- [ ] Query by job: `{app="DFLManager", job="EmailSelectionsJob"}`