### PR TITLE
Fix email parser missing players when tag and content are on same line

### DIFF
--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -316,8 +316,12 @@ public class EmailSelectionsHandler extends BaseHandler {
 
 	private String normaliseTagsToLines(String text) {
 		String[] tags = { TAG_TEAM, TAG_ROUND, TAG_IN, TAG_OUT, TAG_EMG, TAG_END, TAG_START_ID };
+		String[] tagsNeedingTrailingNewline = { TAG_TEAM, TAG_ROUND, TAG_IN, TAG_OUT, TAG_EMG, TAG_END };
 		for (String tag : tags) {
 			text = text.replaceAll("(?i)(?<!\n)(" + Pattern.quote(tag) + ")", "\n$1");
+		}
+		for (String tag : tagsNeedingTrailingNewline) {
+			text = text.replaceAll("(?i)(" + Pattern.quote(tag) + ")(?!\n)", "$1\n");
 		}
 		// Split concatenated players e.g. "21 HARDWICK41 PINK" -> "21 HARDWICK\n41 PINK"
 		text = text.replaceAll("(?<=[A-Za-z])(?=\\d)", "\n");


### PR DESCRIPTION
## Summary

- `normaliseTagsToLines` was inserting a newline before tags but not after, so `[in]9 WARNER` stayed on one line
- The parser entered the `[in]` section and immediately read the **next** line, skipping `9 WARNER` entirely — resulting in empty ins/outs/emergencies
- Insert a newline after each standalone tag (`[in]`, `[out]`, `[emg]`, `[team]`, `[round]`, `[end]`) so content is always on its own line
- `[start id=` excluded from trailing newline to avoid breaking id parsing

## Test plan

- [ ] Reprocess GP round 3 email and verify ins/outs are correctly saved