### PR TITLE
Add safl flag to skip AFL fixture loader in run_refresh.sh

### DIFF
--- a/bin/run_refresh.sh
+++ b/bin/run_refresh.sh
@@ -3,22 +3,37 @@ export CLASSPATH=$APP_HOME/target/dflmngr.jar:$APP_HOME/target/dependency/*
 
 TZ=Austrlia/Melbourne
 run=$1
+skip=$2
 
 if [[ $run == "now" ]]; then
     echo "Running Now"
-    java -classpath $CLASSPATH net.dflmngr.handlers.AflFixtureLoaderHandler && \
-    java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
-    java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator &&\
-    java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
-    java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+    if [[ $skip != "safl" ]]; then
+        java -classpath $CLASSPATH net.dflmngr.handlers.AflFixtureLoaderHandler && \
+        java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator &&\
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+    else
+        java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator &&\
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
+        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+    fi
 else
     if [[ $(date +%u) -eq 1 ]]; then
         echo "Monday Running"
-        java -classpath $CLASSPATH net.dflmngr.handlers.AflFixtureLoaderHandler && \
-        java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
-        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator && \
-        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
-        java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+        if [[ $skip != "safl" ]]; then
+            java -classpath $CLASSPATH net.dflmngr.handlers.AflFixtureLoaderHandler && \
+            java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+        else
+            java -classpath $CLASSPATH net.dflmngr.handlers.DflRoundInfoCalculatorHandler && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.StartRoundJobGenerator && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.EndRoundJobGenerator && \
+            java -classpath $CLASSPATH net.dflmngr.scheduler.generators.ResultsJobGenerator
+        fi
     else
         echo "Not Monday Skipping"
     fi


### PR DESCRIPTION
## Summary
- Add optional second argument `safl` to `bin/run_refresh.sh` that skips the `AflFixtureLoaderHandler` step while still running the round info calculator and job generator steps.
- Behavior is unchanged when the second argument is omitted.

## Test plan
- [x] `mvn test` passes
- [x] Manually traced both the `now` and Monday-only branches with/without `safl`