### PR TITLE
Fix bugs found in codebase review

### DIFF
--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -271,7 +271,9 @@ if (content instanceof InputStream || content instanceof String) {
 						|| (part.getFileName() != null && !part.getFileName().isEmpty())) {
 					String attachementName = part.getFileName();
 					loggerUtils.log("info", "Attachement found, name={}", attachementName);
-					if (attachementName.equalsIgnoreCase("selections.txt")) {
+					if (attachementName == null) {
+						loggerUtils.log("info", "Attachement has no name, skipping");
+					} else if (attachementName.equalsIgnoreCase("selections.txt")) {
 						loggerUtils.log("info", "Message from {}, has selection attachment", from);
 							validationResult = handleSelectionFile(part.getInputStream());
 						validationResult.setFrom(from);
@@ -281,9 +283,13 @@ if (content instanceof InputStream || content instanceof String) {
 							|| attachementName.equalsIgnoreCase("ATT00001.DAT")) {
 						loggerUtils.log("info", "Message from {}, is a TNEF message", from);
 						validationResult = handleTNEFMessage(part.getInputStream(), from);
-						validationResult.setFrom(from);
-						validationResults.add(validationResult);
-						loggerUtils.log("info", "Message from {} handled with ... SUCCESS!", from);
+						if (validationResult != null) {
+							validationResult.setFrom(from);
+							validationResults.add(validationResult);
+							loggerUtils.log("info", "Message from {} handled with ... SUCCESS!", from);
+						} else {
+							loggerUtils.log("info", "Message from {}, TNEF message has no selections.txt", from);
+						}
 					}
 				}
 			}
@@ -402,7 +408,7 @@ if (content instanceof InputStream || content instanceof String) {
 			if (attachment.getNestedMessage() == null) {
 				String filename = attachment.getFilename();
 
-				if (filename.equals("selections.txt")) {
+				if ("selections.txt".equals(filename)) {
 					loggerUtils.log("info", "Message from {}, has selection attachment", from);
 					validationResult = handleSelectionFile(attachment.getRawData());
 				}

--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -120,13 +120,13 @@ public class EmailSelectionsHandler extends BaseHandler {
 
 			sendResponses();
 
-			globalsService.close();
-			dflTeamService.close();
-			dflTeamPlayerService.close();
-
 			loggerUtils.log("info", "Email Selections Handler Completed");
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in EmailSelectionsHandler.execute()", ex);
+		} finally {
+			globalsService.close();
+			dflTeamService.close();
+			dflTeamPlayerService.close();
 		}
 	}
 
@@ -436,9 +436,9 @@ if (content instanceof InputStream || content instanceof String) {
 		while ((line = reader.readLine()) != null) {
 
 			if (line.toLowerCase().contains(TAG_TEAM)) {
-				while (reader.ready()) {
-					line = reader.readLine().trim();
-					if (line.toLowerCase().contains(TAG_ROUND)) {
+				while ((line = reader.readLine()) != null) {
+					line = line.trim();
+					if (line.toLowerCase().contains(TAG_ROUND) || line.toLowerCase().contains(TAG_END)) {
 						break;
 					} else if (line.isEmpty()) {
 						// ignore blank lines
@@ -447,13 +447,16 @@ if (content instanceof InputStream || content instanceof String) {
 					}
 				}
 				loggerUtils.log("debug", "Selections for team: {}", teamCode);
+				if (line == null) {
+					break;
+				}
 			}
 
 			if (line.toLowerCase().contains(TAG_ROUND)) {
-				while (reader.ready()) {
-					line = reader.readLine().trim();
+				while ((line = reader.readLine()) != null) {
+					line = line.trim();
 					if (line.toLowerCase().contains(TAG_IN) || line.toLowerCase().contains(TAG_OUT)
-							|| line.toLowerCase().contains(TAG_EMG)) {
+							|| line.toLowerCase().contains(TAG_EMG) || line.toLowerCase().contains(TAG_END)) {
 						break;
 					} else if (line.isEmpty()) {
 						// ignore blank lines
@@ -462,14 +465,19 @@ if (content instanceof InputStream || content instanceof String) {
 					}
 				}
 				loggerUtils.log("debug", "Selections for round: {}", round);
+				if (line == null) {
+					break;
+				}
 			}
 
 			if (line.toLowerCase().contains(TAG_IN)) {
-				while (reader.ready()) {
-					line = reader.readLine().trim();
+				while ((line = reader.readLine()) != null) {
+					line = line.trim();
 					if (line.toLowerCase().contains(TAG_OUT)) {
 						break;
 					} else if (line.toLowerCase().contains(TAG_EMG)) {
+						break;
+					} else if (line.toLowerCase().contains(TAG_END)) {
 						break;
 					} else if (line.isEmpty()) {
 						// ignore blank lines
@@ -478,14 +486,19 @@ if (content instanceof InputStream || content instanceof String) {
 					}
 				}
 				loggerUtils.log("debug", "Selection in: {}", ins);
+				if (line == null) {
+					break;
+				}
 			}
 
 			if (line.toLowerCase().contains(TAG_OUT)) {
-				while (reader.ready()) {
-					line = reader.readLine().trim();
+				while ((line = reader.readLine()) != null) {
+					line = line.trim();
 					if (line.toLowerCase().contains(TAG_IN)) {
 						break;
 					} else if (line.toLowerCase().contains(TAG_EMG)) {
+						break;
+					} else if (line.toLowerCase().contains(TAG_END)) {
 						break;
 					} else if (line.isEmpty()) {
 						// ignore blank lines
@@ -494,15 +507,20 @@ if (content instanceof InputStream || content instanceof String) {
 					}
 				}
 				loggerUtils.log("debug", "Selection out: {}", outs);
+				if (line == null) {
+					break;
+				}
 			}
 
 			if (line.toLowerCase().contains(TAG_EMG)) {
 				int emgCount = 1;
-				while (reader.ready()) {
-					line = reader.readLine().trim();
+				while ((line = reader.readLine()) != null) {
+					line = line.trim();
 					if (line.toLowerCase().contains(TAG_IN)) {
 						break;
 					} else if (line.toLowerCase().contains(TAG_OUT)) {
+						break;
+					} else if (line.toLowerCase().contains(TAG_END)) {
 						break;
 					} else if (line.isEmpty()) {
 						// ignore blank lines
@@ -518,6 +536,9 @@ if (content instanceof InputStream || content instanceof String) {
 					}
 				}
 				loggerUtils.log("debug", "Selection emergencies: {}", emgs);
+				if (line == null) {
+					break;
+				}
 			}
 		}
 		}
@@ -725,6 +746,11 @@ if (content instanceof InputStream || content instanceof String) {
 				to = validationResult.getFrom();
 			}
 
+			if (to == null || to.isEmpty()) {
+				loggerUtils.log("warn", "No recipient for response (emailOveride/from not set), skipping response");
+				continue;
+			}
+
 			String teamCode = validationResult.getTeamCode();
 
 			Properties properties = new Properties();
@@ -752,7 +778,7 @@ if (content instanceof InputStream || content instanceof String) {
 					if (team != null) {
 						String teamTo = team.getCoachEmail();
 						loggerUtils.log("info", "Team email: {}", teamTo);
-						if (!to.toLowerCase().contains(teamTo.toLowerCase())) {
+						if (teamTo != null && !to.toLowerCase().contains(teamTo.toLowerCase())) {
 							loggerUtils.log("info", "Adding team email");
 							message.addRecipients(Message.RecipientType.TO, InternetAddress.parse(teamTo));
 						}

--- a/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
@@ -149,9 +149,9 @@ public class LadderCalculatorHandler extends BaseHandler {
 		int pointsAgainst = oppositionScore;
 		float averageAgainst = (float)pointsAgainst / round;
 		int pts = calculateWinLossDrawPts(teamScore, oppositionScore);
-		float percentage = ((float)pointsFor / pointsAgainst) * 100;
-		
-		if(round > 1) {
+		float percentage = calculatePercentage(pointsFor, pointsAgainst);
+
+		if(round > 1 && previousLadder != null) {
 			wins = wins + previousLadder.getWins();
 			losses = losses + previousLadder.getLosses();
 			draws = draws + previousLadder.getDraws();
@@ -160,7 +160,7 @@ public class LadderCalculatorHandler extends BaseHandler {
 			pointsAgainst = pointsAgainst + previousLadder.getPointsAgainst();
 			averageAgainst = (float)pointsAgainst / round;
 			pts = pts + previousLadder.getPts();
-			percentage = ((float)pointsFor / pointsAgainst) * 100;
+			percentage = calculatePercentage(pointsFor, pointsAgainst);
 		}
 
 		newLadder.setRound(round);
@@ -180,6 +180,13 @@ public class LadderCalculatorHandler extends BaseHandler {
 		loggerUtils.log("info", "New ladder={}", newLadder);
 		
 		return newLadder;
+	}
+
+	private float calculatePercentage(int pointsFor, int pointsAgainst) {
+		if(pointsAgainst == 0) {
+			return pointsFor * 100f;
+		}
+		return ((float)pointsFor / pointsAgainst) * 100;
 	}
 
 	private int calculateWinLossDrawPts(int teamScore, int oppositionScore) {

--- a/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
@@ -48,17 +48,17 @@ public class LadderCalculatorHandler extends BaseHandler {
 			loggerUtils.log("info", "LadderCalculatorHandler executing round={} ...", round);			
 			handleLadder(round, liveLadderOveride);
 			
-			dflLadderService.close();;
-			dflFixtureService.close();;
-			dflTeamScoresService.close();
-			dflSelectedTeamService.close();
-			dflPlayerScoresService.close();
-			dflPlayerPredictedScoresService.close();
-			
 			loggerUtils.log("info", "LadderCalculatorHandler completed");
 			
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in LadderCalculatorHandler.execute(), round=" + round, ex);
+		} finally {
+			dflLadderService.close();
+			dflFixtureService.close();
+			dflTeamScoresService.close();
+			dflSelectedTeamService.close();
+			dflPlayerScoresService.close();
+			dflPlayerPredictedScoresService.close();
 		}
 	}
 		

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -88,6 +88,11 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			loggerUtils.log("info", "Handling team scores");
 			handleTeamScores(round, dflRoundInfo, predictedScores);
 
+			loggerUtils.log("info", "ScoresCalculator completed");
+
+		} catch (Exception ex) {
+			loggerUtils.logException("Error in ScoresCalculatorHandler.execute(), round=" + round, ex);
+		} finally {
 			rawPlayerStatsService.close();
 			dflPlayerService.close();
 			dflTeamPlayerService.close();
@@ -99,11 +104,6 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			aflFixtureService.close();
 			globalsService.close();
 			dflPlayerPredictedScoresService.close();
-
-			loggerUtils.log("info", "ScoresCalculator completed");
-
-		} catch (Exception ex) {
-			loggerUtils.logException("Error in ScoresCalculatorHandler.execute(), round=" + round, ex);
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -283,7 +283,8 @@ public class ScoresCalculatorHandler extends BaseHandler {
 						   				player.getAflClub(), round, selectedPlayer.getRound());
 
 						if(round == selectedPlayer.getRound()) {
-							int score = predictedScores.get(selectedPlayer.getPlayerId()).getPredictedScore();
+							DflPlayerPredictedScores predictedScore = predictedScores.get(selectedPlayer.getPlayerId());
+							int score = predictedScore != null ? predictedScore.getPredictedScore() : 25;
 							scores.put(selectedPlayer.getPlayerId(), score);
 	
 							selectedPlayer.setHasPlayed(true);

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -68,14 +68,6 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 
 			loggerUtils.log("info", "Validation result={}", validationResult);
 
-			dflSelectedTeamService.close();
-			dflTeamPlayerService.close();
-			dflPlayerService.close();
-			globalsService.close();
-			dflRoundInfoService.close();
-			dflEarlyInsAndOutsService.close();
-			aflFixtureService.close();
-
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in SelectedTeamValidationHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
 			if(validationResult == null) {
@@ -87,6 +79,15 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				validationResult.setRound(round);
 				validationResult.setTeamCode(teamCode);
 			}
+		} finally {
+			dflSelectedTeamService.close();
+			dflTeamPlayerService.close();
+			dflPlayerService.close();
+			globalsService.close();
+			dflRoundInfoService.close();
+			dflEarlyInsAndOutsService.close();
+			aflFixtureService.close();
+			dflSelectionIdsService.close();
 		}
 
 		return validationResult;

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -337,7 +337,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						} else {
 							boolean alreadySelected = false;
 							for(DflSelectedPlayer selectedPlayer : selectedTeam) {
-								if(emergency == selectedPlayer.getPlayerId()) {
+								if(emergency == selectedPlayer.getTeamPlayerId()) {
 									alreadySelected = true;
 									break;
 								}
@@ -384,7 +384,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 			if(validationResult.selectedWarning) {
 				validationResult.selectedWarnPlayers = selectedWarnPlayers;
 			}
-			if(validationResult.selectedWarning) {
+			if(validationResult.droppedWarning) {
 				validationResult.droppedWarnPlayers = droppedWarnPlayers;
 			}
 			if(validationResult.duplicateIns) {

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -78,6 +78,15 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in SelectedTeamValidationHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
+			if(validationResult == null) {
+				validationResult = new SelectedTeamValidation();
+				validationResult.unknownError = true;
+				validationResult.selectionFileMissing = false;
+				validationResult.roundCompleted = false;
+				validationResult.lockedOut = false;
+				validationResult.setRound(round);
+				validationResult.setTeamCode(teamCode);
+			}
 		}
 
 		return validationResult;
@@ -97,6 +106,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		List<Integer> checkedIns = new ArrayList<>();
 		List<Integer> checkedOuts = new ArrayList<>();
 		List<Double> checkedEmgs = new ArrayList<>();
+		boolean playerNumbersOk = true;
 
 		List<DflPlayer> selectedWarnPlayers = new ArrayList<>();
 		List<DflPlayer> droppedWarnPlayers = new ArrayList<>();
@@ -144,7 +154,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				selectedTeam = new ArrayList<>();
 
 				for(int in : ins) {
+					if(in < 1 || in > 45) {
+						loggerUtils.log("info", "Selected player outside player range, teamPlayerId={}.", in);
+						playerNumbersOk = false;
+						break;
+					}
+
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(teamCode, in);
+					if(teamPlayer == null) {
+						loggerUtils.log("info", "Selected player does not exist, teamPlayerId={}.", in);
+						playerNumbersOk = false;
+						break;
+					}
 					DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
 
 					if(checkedIns.contains(in)) {
@@ -152,25 +173,17 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						validationResult.duplicateIns = true;
 						dupInPlayers.add(player);
 					} else {
-						if(in < 1 || in > 45) {
-							validationResult.selectionFileMissing = false;
-							validationResult.roundCompleted = false;
-							validationResult.lockedOut = false;
-							loggerUtils.log("info", "Selected player outside player range, teamPlayerId={}.", in);
-							break;
-						} else {
-							DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
+						DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
 
-							selectedPlayer.setPlayerId(player.getPlayerId());
-							selectedPlayer.setRound(round);
-							selectedPlayer.setTeamCode(teamCode);
-							selectedPlayer.setTeamPlayerId(in);
-							selectedPlayer.setEmergency(0);
-							selectedPlayer.setDnp(false);
+						selectedPlayer.setPlayerId(player.getPlayerId());
+						selectedPlayer.setRound(round);
+						selectedPlayer.setTeamCode(teamCode);
+						selectedPlayer.setTeamPlayerId(in);
+						selectedPlayer.setEmergency(0);
+						selectedPlayer.setDnp(false);
 
-							selectedTeam.add(selectedPlayer);
-							loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
-						}
+						selectedTeam.add(selectedPlayer);
+						loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
 
 						checkedIns.add(in);
 					}
@@ -179,7 +192,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				for(Double emg : emergencies) {
 					int emergency = emg.intValue();
 
+					if(emergency < 1 || emergency > 45) {
+						loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
+						playerNumbersOk = false;
+						break;
+					}
+
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(teamCode, emergency);
+					if(teamPlayer == null) {
+						loggerUtils.log("info", "Emergency player does not exist, teamPlayerId={}.", emergency);
+						playerNumbersOk = false;
+						break;
+					}
 					DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
 
 					if(checkedEmgs.contains(emg) || checkedIns.contains(emergency)) {
@@ -187,32 +211,24 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						validationResult.duplicateEmgs = true;
 						dupEmgPlayers.add(player);
 					} else {
-						if(emergency < 1 || emergency > 45) {
-							validationResult.selectionFileMissing = false;
-							validationResult.roundCompleted = false;
-							validationResult.lockedOut = false;
-							loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
-							break;
+						DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
+
+						selectedPlayer.setPlayerId(player.getPlayerId());
+						selectedPlayer.setRound(round);
+						selectedPlayer.setTeamCode(teamCode);
+						selectedPlayer.setTeamPlayerId(emergency);
+
+						int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
+						if(e1e2 == 1) {
+							selectedPlayer.setEmergency(1);
 						} else {
-							DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
-
-							selectedPlayer.setPlayerId(player.getPlayerId());
-							selectedPlayer.setRound(round);
-							selectedPlayer.setTeamCode(teamCode);
-							selectedPlayer.setTeamPlayerId(emergency);
-
-							int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
-							if(e1e2 == 1) {
-								selectedPlayer.setEmergency(1);
-							} else {
-								selectedPlayer.setEmergency(2);
-							}
-
-							selectedPlayer.setDnp(false);
-
-							selectedTeam.add(selectedPlayer);
-							loggerUtils.log("info", "Added selectedPlayer={}, as emergency", selectedPlayer);
+							selectedPlayer.setEmergency(2);
 						}
+
+						selectedPlayer.setDnp(false);
+
+						selectedTeam.add(selectedPlayer);
+						loggerUtils.log("info", "Added selectedPlayer={}, as emergency", selectedPlayer);
 
 						checkedEmgs.add(emg);
 					}
@@ -235,7 +251,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				List<Integer> outs = insAndOuts.get("out");
 
 				for(int in : ins) {
+					if(in < 1 || in > 45) {
+						loggerUtils.log("info", "Selected player outside player range, teamPlayerId={}.", in);
+						playerNumbersOk = false;
+						break;
+					}
+
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(teamCode, in);
+					if(teamPlayer == null) {
+						loggerUtils.log("info", "Selected player does not exist, teamPlayerId={}.", in);
+						playerNumbersOk = false;
+						break;
+					}
 					DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
 
 					if(checkedIns.contains(in)) {
@@ -243,40 +270,34 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						validationResult.duplicateIns = true;
 						dupInPlayers.add(player);
 					} else {
-						if(in < 1 || in > 45) {
-							validationResult.selectionFileMissing = false;
-							loggerUtils.log("info", "Selected player outside player range, teamPlayerId={}.", in);
-							break;
-						} else {
-							boolean found = false;
-							boolean isEmg = false;
-							for(DflSelectedPlayer selectedPlayer : selectedTeam) {
-								if(in == selectedPlayer.getTeamPlayerId()) {
-									found = true;
-									if(selectedPlayer.isEmergency() == 1 || selectedPlayer.isEmergency() == 2) {
-										isEmg = true;
-									}
-									break;
+						boolean found = false;
+						boolean isEmg = false;
+						for(DflSelectedPlayer selectedPlayer : selectedTeam) {
+							if(in == selectedPlayer.getTeamPlayerId()) {
+								found = true;
+								if(selectedPlayer.isEmergency() == 1 || selectedPlayer.isEmergency() == 2) {
+									isEmg = true;
 								}
+								break;
 							}
-							if(!found) {
-								DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
+						}
+						if(!found) {
+							DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
 
-								selectedPlayer.setPlayerId(player.getPlayerId());
-								selectedPlayer.setRound(round);
-								selectedPlayer.setTeamCode(teamCode);
-								selectedPlayer.setTeamPlayerId(in);
-								selectedPlayer.setEmergency(0);
-								selectedPlayer.setDnp(false);
+							selectedPlayer.setPlayerId(player.getPlayerId());
+							selectedPlayer.setRound(round);
+							selectedPlayer.setTeamCode(teamCode);
+							selectedPlayer.setTeamPlayerId(in);
+							selectedPlayer.setEmergency(0);
+							selectedPlayer.setDnp(false);
 
-								selectedTeam.add(selectedPlayer);
-								loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
-							} else {
-								if(!isEmg) {
-									loggerUtils.log("info", "Player already selected, teamPlayerId={}.", in);
-									selectedWarnPlayers.add(player);
-									validationResult.selectedWarning = true;
-								}
+							selectedTeam.add(selectedPlayer);
+							loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
+						} else {
+							if(!isEmg) {
+								loggerUtils.log("info", "Player already selected, teamPlayerId={}.", in);
+								selectedWarnPlayers.add(player);
+								validationResult.selectedWarning = true;
 							}
 						}
 
@@ -285,7 +306,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				}
 
 				for(int out : outs) {
+					if(out < 1 || out > 45) {
+						loggerUtils.log("info", "Dropped player outside player range, teamPlayerId={}.", out);
+						playerNumbersOk = false;
+						break;
+					}
+
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(teamCode, out);
+					if(teamPlayer == null) {
+						loggerUtils.log("info", "Dropped player does not exist, teamPlayerId={}.", out);
+						playerNumbersOk = false;
+						break;
+					}
 					DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
 
 					if(checkedOuts.contains(out)) {
@@ -293,25 +325,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						validationResult.duplicateOuts = true;
 						dupOutPlayers.add(player);
 					} else {
-						if(out < 1 || out > 45) {
-							validationResult = new SelectedTeamValidation();
-							validationResult.selectionFileMissing = false;
-							loggerUtils.log("info", "Dropped player outside player range, teamPlayerId={}.", out);
-							break;
-						} else {
-							boolean found = false;
-							for(DflSelectedPlayer selectedPlayer : selectedTeam) {
-								if(selectedPlayer.getTeamPlayerId() == out) {
-									playersToRemove.add(selectedPlayer);
-									found = true;
-									loggerUtils.log("info", "Removing selectedPlayer={}.", selectedPlayer);
-								}
+						boolean found = false;
+						for(DflSelectedPlayer selectedPlayer : selectedTeam) {
+							if(selectedPlayer.getTeamPlayerId() == out) {
+								playersToRemove.add(selectedPlayer);
+								found = true;
+								loggerUtils.log("info", "Removing selectedPlayer={}.", selectedPlayer);
 							}
-							if(!found) {
-								loggerUtils.log("info", "Dropped player not selected, teamPlayerId={}.", out);
-								droppedWarnPlayers.add(player);
-								validationResult.droppedWarning = true;
-							}
+						}
+						if(!found) {
+							loggerUtils.log("info", "Dropped player not selected, teamPlayerId={}.", out);
+							droppedWarnPlayers.add(player);
+							validationResult.droppedWarning = true;
 						}
 
 						checkedOuts.add(out);
@@ -321,7 +346,18 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				for(Double emg : emergencies) {
 					int emergency = emg.intValue();
 
+					if(emergency < 1 || emergency > 45) {
+						loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
+						playerNumbersOk = false;
+						break;
+					}
+
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(teamCode, emergency);
+					if(teamPlayer == null) {
+						loggerUtils.log("info", "Emergency player does not exist, teamPlayerId={}.", emergency);
+						playerNumbersOk = false;
+						break;
+					}
 					DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
 
 					if(checkedEmgs.contains(emg) || checkedIns.contains(emergency)) {
@@ -329,41 +365,34 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						validationResult.duplicateEmgs = true;
 						dupEmgPlayers.add(player);
 					} else {
-						if(emergency < 1 || emergency > 45) {
-							validationResult = new SelectedTeamValidation();
-							validationResult.selectionFileMissing = false;
-							loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
-							break;
+						boolean alreadySelected = false;
+						for(DflSelectedPlayer selectedPlayer : selectedTeam) {
+							if(emergency == selectedPlayer.getTeamPlayerId()) {
+								alreadySelected = true;
+								break;
+							}
+						}
+						if(alreadySelected) {
+							loggerUtils.log("info", "Emergency emg={}.", emergency);
 						} else {
-							boolean alreadySelected = false;
-							for(DflSelectedPlayer selectedPlayer : selectedTeam) {
-								if(emergency == selectedPlayer.getTeamPlayerId()) {
-									alreadySelected = true;
-									break;
-								}
-							}
-							if(alreadySelected) {
-								loggerUtils.log("info", "Emergency emg={}.", emergency);
+							DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
+
+							selectedPlayer.setPlayerId(player.getPlayerId());
+							selectedPlayer.setRound(round);
+							selectedPlayer.setTeamCode(teamCode);
+							selectedPlayer.setTeamPlayerId(emergency);
+
+							int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
+							if(e1e2 == 1) {
+								selectedPlayer.setEmergency(1);
 							} else {
-								DflSelectedPlayer selectedPlayer = new DflSelectedPlayer();
-
-								selectedPlayer.setPlayerId(player.getPlayerId());
-								selectedPlayer.setRound(round);
-								selectedPlayer.setTeamCode(teamCode);
-								selectedPlayer.setTeamPlayerId(emergency);
-
-								int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
-								if(e1e2 == 1) {
-									selectedPlayer.setEmergency(1);
-								} else {
-									selectedPlayer.setEmergency(2);
-								}
-
-								selectedPlayer.setDnp(false);
-
-								selectedTeam.add(selectedPlayer);
-								loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
+								selectedPlayer.setEmergency(2);
 							}
+
+							selectedPlayer.setDnp(false);
+
+							selectedTeam.add(selectedPlayer);
+							loggerUtils.log("info", "Added selectedPlayer={}.", selectedPlayer);
 						}
 
 						checkedEmgs.add(emg);
@@ -371,6 +400,15 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				}
 
 				selectedTeam.removeAll(playersToRemove);
+			}
+
+			if(!playerNumbersOk) {
+				validationResult.selectionFileMissing = false;
+				validationResult.roundCompleted = false;
+				validationResult.lockedOut = false;
+				validationResult.teamPlayerCheckOk = false;
+				loggerUtils.log("info", "Pre checks FAILED, invalid player numbers");
+				return validationResult;
 			}
 
 			loggerUtils.log("info", "Pre checks PASSED, validating selected team");
@@ -445,7 +483,13 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 
 		for(DflSelectedPlayer selectedPlayer : selectedTeam) {
 			DflTeamPlayer teamPlayer = dflTeamPlayerService.getTeamPlayerForTeam(selectedPlayer.getTeamCode(), selectedPlayer.getTeamPlayerId());
-			DflPlayer player = dflPlayerService.get(teamPlayer.getPlayerId());
+			DflPlayer player = teamPlayer != null ? dflPlayerService.get(teamPlayer.getPlayerId()) : null;
+
+			if(player == null) {
+				loggerUtils.log("warn", "No player found for teamCode={} teamPlayerId={}, skipping position checks",
+								selectedPlayer.getTeamCode(), selectedPlayer.getTeamPlayerId());
+				continue;
+			}
 
 			String position = player.getPosition().toLowerCase();
 

--- a/src/main/java/net/dflmngr/model/service/impl/GlobalsServiceImpl.java
+++ b/src/main/java/net/dflmngr/model/service/impl/GlobalsServiceImpl.java
@@ -128,14 +128,16 @@ public class GlobalsServiceImpl extends GenericServiceImpl<Globals, GlobalsPK> i
 	public String getGroundTimeZone(String ground) {
 
 		String timezone = "";
-		String code = ground;
 		String groupCode = "timezone";
 
-		timezone = getValue(code, groupCode);
+		try {
+			timezone = getValue(ground, groupCode);
+		} catch (MissingGlobalConfig e) {
+			timezone = "";
+		}
 
-		if(timezone.equals("")) {
-			code = "default";
-			timezone = getValue(code, groupCode);
+		if(timezone == null || timezone.equals("")) {
+			timezone = getValue("default", groupCode);
 		}
 
 		return timezone;

--- a/src/main/java/net/dflmngr/reports/struct/ResultsFixtureTabTeamStruct.java
+++ b/src/main/java/net/dflmngr/reports/struct/ResultsFixtureTabTeamStruct.java
@@ -277,9 +277,9 @@ public class ResultsFixtureTabTeamStruct implements Comparator<ResultsFixtureTab
 		int less = -1;
 		int greater = 1;
 		
-		String o1Position = o2.getPosition();
+		String o1Position = o1.getPosition();
 		String o2Position = o2.getPosition();
-		
+
 		if(o1Position.compareTo(o2Position) < 0) {
 			return less;
 		}
@@ -291,15 +291,15 @@ public class ResultsFixtureTabTeamStruct implements Comparator<ResultsFixtureTab
 				if(o2.getScore().equals("dnp")) {
 					return equal;
 				} else {
-					return less;
+					return greater;
 				}
 			}
 			if(o2.getScore().equals("dnp")) {
-				return greater;
+				return less;
 			}
-			
-			int o1Score = Integer.parseInt(o1.getScore());
-			int o2Score = Integer.parseInt(o2.getScore());
+
+			int o1Score = o1.getScore().equals("") ? 0 : Integer.parseInt(o1.getScore());
+			int o2Score = o2.getScore().equals("") ? 0 : Integer.parseInt(o2.getScore());
 			
 			if(o1Score > o2Score) {
 				return less;

--- a/src/main/java/net/dflmngr/utils/CronExpressionCreator.java
+++ b/src/main/java/net/dflmngr/utils/CronExpressionCreator.java
@@ -90,6 +90,10 @@ public class CronExpressionCreator implements Serializable {
 
             daysString = sb.toString();
 
+            if (daysString.isEmpty()) {
+                throw new IllegalStateException("Recurring cron expression requires at least one day to be set");
+            }
+
             cronExp = "0 " + minutes + " " + hour + " ? * " + daysString;
         } else {
             String startDate = getStartDate();

--- a/src/main/java/net/dflmngr/utils/DflmngrUtils.java
+++ b/src/main/java/net/dflmngr/utils/DflmngrUtils.java
@@ -27,8 +27,6 @@ public class DflmngrUtils {
 			defaultTimezone = globalsService.getGroundTimeZone("default");
 	};
 
-	public static final SimpleDateFormat dateDbFormat = new SimpleDateFormat("yyyyMMddHHmmssSSS");
-
 	/*
 	public static Date applyDefaultTimezone(Date date) throws Exception {
 		GlobalsService globalsService = new GlobalsServiceImpl();

--- a/src/test/java/net/dflmngr/handlers/SelectedTeamValidationHandlerTest.java
+++ b/src/test/java/net/dflmngr/handlers/SelectedTeamValidationHandlerTest.java
@@ -1,0 +1,204 @@
+package net.dflmngr.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import net.dflmngr.model.entity.DflPlayer;
+import net.dflmngr.model.entity.DflRoundInfo;
+import net.dflmngr.model.entity.DflRoundMapping;
+import net.dflmngr.model.entity.DflSelectedPlayer;
+import net.dflmngr.model.entity.DflTeamPlayer;
+import net.dflmngr.model.service.AflFixtureService;
+import net.dflmngr.model.service.DflEarlyInsAndOutsService;
+import net.dflmngr.model.service.DflPlayerService;
+import net.dflmngr.model.service.DflRoundInfoService;
+import net.dflmngr.model.service.DflSelectedTeamService;
+import net.dflmngr.model.service.DflSelectionIdsService;
+import net.dflmngr.model.service.DflTeamPlayerService;
+import net.dflmngr.model.service.GlobalsService;
+import net.dflmngr.service.ServiceFactory;
+import net.dflmngr.validation.SelectedTeamValidation;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SelectedTeamValidationHandlerTest {
+
+	private static final String TEAM_CODE = "TEST";
+
+	@Mock private ServiceFactory serviceFactory;
+	@Mock private DflSelectedTeamService dflSelectedTeamService;
+	@Mock private DflTeamPlayerService dflTeamPlayerService;
+	@Mock private DflPlayerService dflPlayerService;
+	@Mock private GlobalsService globalsService;
+	@Mock private DflRoundInfoService dflRoundInfoService;
+	@Mock private DflEarlyInsAndOutsService dflEarlyInsAndOutsService;
+	@Mock private AflFixtureService aflFixtureService;
+	@Mock private DflSelectionIdsService dflSelectionIdsService;
+
+	private SelectedTeamValidationHandler handler;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		when(serviceFactory.createDflSelectedTeamService()).thenReturn(dflSelectedTeamService);
+		when(serviceFactory.createDflTeamPlayerService()).thenReturn(dflTeamPlayerService);
+		when(serviceFactory.createDflPlayerService()).thenReturn(dflPlayerService);
+		when(serviceFactory.createGlobalsService()).thenReturn(globalsService);
+		when(serviceFactory.createDflRoundInfoService()).thenReturn(dflRoundInfoService);
+		when(serviceFactory.createDflEarlyInsAndOutsService()).thenReturn(dflEarlyInsAndOutsService);
+		when(serviceFactory.createAflFixtureService()).thenReturn(aflFixtureService);
+		when(serviceFactory.createDflSelectionIdsService()).thenReturn(dflSelectionIdsService);
+
+		setFactoryInstance(serviceFactory);
+		try {
+			handler = new SelectedTeamValidationHandler();
+		} finally {
+			setFactoryInstance(null);
+		}
+
+		when(aflFixtureService.getAflRoundComplete(anyInt())).thenReturn(false);
+		when(dflSelectionIdsService.selectionIdExists(anyInt(), any(), any())).thenReturn(false);
+
+		DflRoundInfo roundInfo = new DflRoundInfo();
+		DflRoundMapping mapping = new DflRoundMapping();
+		mapping.setAflRound(1);
+		List<DflRoundMapping> mappings = new ArrayList<>();
+		mappings.add(mapping);
+		roundInfo.setRoundMapping(mappings);
+		when(dflRoundInfoService.get(anyInt())).thenReturn(roundInfo);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		setFactoryInstance(null);
+	}
+
+	private static void setFactoryInstance(ServiceFactory factory) throws Exception {
+		Field field = ServiceFactory.class.getDeclaredField("instance");
+		field.setAccessible(true);
+		field.set(null, factory);
+	}
+
+	private DflSelectedPlayer selectedPlayer(int teamPlayerId, int playerId, int emergency) {
+		DflSelectedPlayer player = new DflSelectedPlayer();
+		player.setTeamPlayerId(teamPlayerId);
+		player.setPlayerId(playerId);
+		player.setRound(1);
+		player.setTeamCode(TEAM_CODE);
+		player.setEmergency(emergency);
+		player.setDnp(false);
+		return player;
+	}
+
+	private void stubTeamPlayer(int teamPlayerId, int playerId, String position) {
+		DflTeamPlayer teamPlayer = new DflTeamPlayer();
+		teamPlayer.setTeamCode(TEAM_CODE);
+		teamPlayer.setTeamPlayerId(teamPlayerId);
+		teamPlayer.setPlayerId(playerId);
+		when(dflTeamPlayerService.getTeamPlayerForTeam(TEAM_CODE, teamPlayerId)).thenReturn(teamPlayer);
+
+		DflPlayer player = new DflPlayer();
+		player.setPlayerId(playerId);
+		player.setPosition(position);
+		when(dflPlayerService.get(playerId)).thenReturn(player);
+	}
+
+	private Map<String, List<Integer>> insAndOuts(List<Integer> ins, List<Integer> outs) {
+		Map<String, List<Integer>> map = new HashMap<>();
+		map.put("in", ins);
+		map.put("out", outs);
+		return map;
+	}
+
+	@Test
+	void execute_shouldFailTeamPlayerCheck_whenSelectedPlayerDoesNotExist() {
+		when(globalsService.getCurrentRound()).thenReturn("1");
+		// no team player stubbed for 30 -> lookup returns null
+
+		SelectedTeamValidation result = handler.execute(1, TEAM_CODE,
+				insAndOuts(new ArrayList<>(List.of(30)), new ArrayList<>()), new ArrayList<>(), "noid");
+
+		assertNotNull(result);
+		assertFalse(result.isValid());
+		assertFalse(result.teamPlayerCheckOk);
+		assertFalse(result.unknownError);
+	}
+
+	@Test
+	void execute_shouldFailTeamPlayerCheck_whenSelectedPlayerOutsideRange() {
+		when(globalsService.getCurrentRound()).thenReturn("1");
+
+		SelectedTeamValidation result = handler.execute(1, TEAM_CODE,
+				insAndOuts(new ArrayList<>(List.of(50)), new ArrayList<>()), new ArrayList<>(), "noid");
+
+		assertNotNull(result);
+		assertFalse(result.isValid());
+		assertFalse(result.teamPlayerCheckOk);
+		assertFalse(result.unknownError);
+		verify(dflTeamPlayerService, never()).getTeamPlayerForTeam(anyString(), anyInt());
+	}
+
+	@Test
+	void execute_shouldAttachDroppedWarnPlayers_whenDroppedPlayerNotSelected() {
+		when(globalsService.getCurrentRound()).thenReturn("2");
+
+		List<DflSelectedPlayer> previousTeam = new ArrayList<>();
+		previousTeam.add(selectedPlayer(5, 105, 0));
+		when(dflSelectedTeamService.getSelectedTeamForRound(1, TEAM_CODE)).thenReturn(previousTeam);
+
+		stubTeamPlayer(5, 105, "mid");
+		stubTeamPlayer(9, 109, "fwd");
+
+		SelectedTeamValidation result = handler.execute(2, TEAM_CODE,
+				insAndOuts(new ArrayList<>(), new ArrayList<>(List.of(9))), new ArrayList<>(), "noid");
+
+		assertNotNull(result);
+		assertTrue(result.droppedWarning);
+		assertNotNull(result.droppedWarnPlayers);
+		assertEquals(1, result.droppedWarnPlayers.size());
+		assertEquals(109, result.droppedWarnPlayers.get(0).getPlayerId());
+	}
+
+	@Test
+	void execute_shouldNotAddEmergency_whenPlayerAlreadySelected() {
+		when(globalsService.getCurrentRound()).thenReturn("2");
+
+		List<DflSelectedPlayer> previousTeam = new ArrayList<>();
+		previousTeam.add(selectedPlayer(7, 107, 0));
+		when(dflSelectedTeamService.getSelectedTeamForRound(1, TEAM_CODE)).thenReturn(previousTeam);
+
+		stubTeamPlayer(7, 107, "mid");
+
+		SelectedTeamValidation result = handler.execute(2, TEAM_CODE,
+				insAndOuts(new ArrayList<>(), new ArrayList<>()),
+				new ArrayList<>(List.of(7.1)), "noid");
+
+		assertNotNull(result);
+		// the already-selected emergency must not be added to the team again:
+		// one lookup in the emergency pre-check plus one in validateTeam
+		verify(dflTeamPlayerService, times(2)).getTeamPlayerForTeam(TEAM_CODE, 7);
+	}
+}

--- a/src/test/java/net/dflmngr/model/service/impl/GlobalsServiceImplTest.java
+++ b/src/test/java/net/dflmngr/model/service/impl/GlobalsServiceImplTest.java
@@ -1,0 +1,51 @@
+package net.dflmngr.model.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.dflmngr.jpa.AbstractDatabaseTest;
+import net.dflmngr.model.entity.Globals;
+
+class GlobalsServiceImplTest extends AbstractDatabaseTest {
+
+	private GlobalsServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		service = new GlobalsServiceImpl();
+
+		List<Globals> globals = new ArrayList<>();
+		globals.add(timezoneRow("default", "Australia/Melbourne"));
+		globals.add(timezoneRow("Perth Stadium", "Australia/Perth"));
+		service.replaceAll(globals);
+	}
+
+	@AfterEach
+	void tearDown() {
+		service.close();
+	}
+
+	private Globals timezoneRow(String code, String value) {
+		Globals row = new Globals();
+		row.setCode(code);
+		row.setGroupCode("timezone");
+		row.setValue(value);
+		return row;
+	}
+
+	@Test
+	void getGroundTimeZone_shouldReturnGroundTimezone_whenGroundIsConfigured() {
+		assertEquals("Australia/Perth", service.getGroundTimeZone("Perth Stadium"));
+	}
+
+	@Test
+	void getGroundTimeZone_shouldFallBackToDefault_whenGroundIsUnknown() {
+		assertEquals("Australia/Melbourne", service.getGroundTimeZone("Unknown Ground"));
+	}
+}

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -8,10 +8,12 @@
     <persistence-unit name="dflmngr-test" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 
+        <class>net.dflmngr.model.entity.Globals</class>
+
         <properties>
             <!-- Default H2 configuration (overridden programmatically for PostgreSQL in CI) -->
             <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;NON_KEYWORDS=VALUE"/>
             <property name="jakarta.persistence.jdbc.user" value="sa"/>
             <property name="jakarta.persistence.jdbc.password" value=""/>
 


### PR DESCRIPTION
## Summary

A bug-hunt across the codebase turned up 8 confirmed bugs plus several lower-severity issues. This PR fixes all of them, in five commits ordered from one-liners to hardening.

### Confirmed bugs fixed

1. **Dead default-timezone fallback** (`GlobalsServiceImpl.getGroundTimeZone`) — `getValue()` throws `MissingGlobalConfig` rather than returning `""`, so the fallback to the `default` timezone could never run; an unmapped ground crashed instead. Now catches the exception and falls back.
2. **Emergency "already selected" check compared the wrong field** (`SelectedTeamValidationHandler`) — a team player number (1–45) was compared against the global player id, so naming an already-selected player as emergency added them to the team twice.
3. **`droppedWarnPlayers` attached under the wrong flag** — it was only set when `selectedWarning` was true, leaving it null and NPE-ing the success response email, which aborted every remaining coach's response in the batch.
4. **Invalid player numbers NPE'd before the range check** — a typo like `50` in a selections email crashed through a null lookup and a null return from `execute()`, so the coach got the generic "unknown error" email. Bad numbers now fail validation cleanly with `teamPlayerCheckOk=false`.
5. **TNEF/attachment NPEs** (`EmailSelectionsHandler`) — null attachment filenames and TNEF messages without a `selections.txt` crashed message processing.
6. **Predicted-score NPE aborted the whole scores calculation** (`ScoresCalculatorHandler`) — a missing predicted-scores row while the use-average global was set killed the round's team scores. Falls back to the default score (25).
7. **Ladder calculator NPE / Infinity percentage** (`LadderCalculatorHandler`) — missing previous-ladder row NPE'd (silently, ladder not updated); zero points-against stored `Infinity` in the DB.
8. **`ResultsFixtureTabTeamStruct.compare()` read `o2`'s position for both sides** (latent — sorts use `compareTo`) — also aligned dnp ordering with `compareTo` and guarded empty scores.

### Hardening

- `handleSelectionFile` no longer uses `reader.ready()` as an EOF test (could silently truncate attachment parsing) and honours the `[end]` tag instead of throwing `NumberFormatException` on it.
- Response sending skips gracefully when no recipient is available (`EMAIL_OVERIDE` unset outside production) and guards null coach emails.
- `CronExpressionCreator` fails fast on a recurring schedule with no days selected instead of producing an invalid cron expression.
- Removed the unused, non-thread-safe static `SimpleDateFormat dateDbFormat`.
- Handler services are now closed in `finally` blocks (EntityManagers leaked on failure paths before), and the never-closed `dflSelectionIdsService` is closed.

### Question for review

`ScoresCalculatorHandler` line ~480: the `def` emergency-replacement case requires `defCount < 6 && defCount > 4`, unlike every other position which only checks `< max`. It looks like a leftover, but I left it unchanged — please confirm whether the `> 4` condition is intentional.

## Tests

- New `SelectedTeamValidationHandlerTest` (mocked `ServiceFactory`): bad player numbers fail validation cleanly (range and nonexistent), dropped-warning results expose `droppedWarnPlayers`, already-selected emergencies aren't double-added.
- New `GlobalsServiceImplTest` (H2-backed): unknown ground falls back to the default timezone. Registers the `Globals` entity in the test persistence unit and adds `NON_KEYWORDS=VALUE` to the H2 URL (`VALUE` is an H2 reserved word; the CI PostgreSQL override is unaffected).
- Full suite: 139 tests, 0 failures.
