### PR TITLE
Remove leftover lower bound on def emergency replacement

### DIFF
--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -478,7 +478,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 										}
 										break;
 									case "def":
-										if(defCount < 6 && defCount > 4) {
+										if(defCount < 6) {
 											replacement = emergency;
 											defCount++;
 										}


### PR DESCRIPTION
## Summary

Follow-up to #256's open question about `ScoresCalculatorHandler`.

`defCount < 6 && defCount > 4` in the DNP emergency-replacement switch is a leftover: fc60ece (11 Apr 2025) added a lower bound to every position's emergency check, and the same-day rework in 7fb1f4a moved that logic to the `allowEmg` guard and removed the lower bounds from every position — except `def`, which was missed.

The effect was that a defender emergency could only replace a DNP when the team had exactly 5 defenders, while every other position only requires bench room. This aligns `def` with the rest:

```java
case "def":
    if(defCount < 6) {
```

## Tests

Full suite: 139 tests, 0 failures.