### PR TITLE
Extract PositionCounts to replace duplicated position switches

### DIFF
--- a/src/main/java/net/dflmngr/handlers/PositionCounts.java
+++ b/src/main/java/net/dflmngr/handlers/PositionCounts.java
@@ -1,0 +1,90 @@
+package net.dflmngr.handlers;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.dflmngr.exceptions.UnknownPositionException;
+
+/**
+ * Tracks how many players a team is fielding at each position and applies
+ * the per-position limits (ff 2, fwd 6, rck 2, mid 6, def 6, fb 2).
+ * A position at its limit means its bench slot is filled.
+ */
+public class PositionCounts {
+
+	private static final Map<String, Integer> LIMITS = createLimits();
+
+	private final Map<String, Integer> counts = new LinkedHashMap<>();
+
+	private static Map<String, Integer> createLimits() {
+		Map<String, Integer> limits = new LinkedHashMap<>();
+		limits.put("ff", 2);
+		limits.put("fwd", 6);
+		limits.put("rck", 2);
+		limits.put("mid", 6);
+		limits.put("def", 6);
+		limits.put("fb", 2);
+		return limits;
+	}
+
+	public static int limitFor(String position) {
+		return LIMITS.get(checkKnown(position));
+	}
+
+	public void increment(String position) {
+		counts.merge(checkKnown(position), 1, Integer::sum);
+	}
+
+	public void decrement(String position) {
+		counts.merge(checkKnown(position), -1, Integer::sum);
+	}
+
+	public int count(String position) {
+		return counts.getOrDefault(checkKnown(position), 0);
+	}
+
+	public boolean hasRoom(String position) {
+		return count(position) < limitFor(position);
+	}
+
+	public boolean isFull(String position) {
+		return count(position) >= limitFor(position);
+	}
+
+	public boolean overLimit(String position) {
+		return count(position) > limitFor(position);
+	}
+
+	public boolean anyOverLimit() {
+		return LIMITS.keySet().stream().anyMatch(this::overLimit);
+	}
+
+	public List<String> benchPositions() {
+		List<String> bench = new ArrayList<>();
+		for(String position : LIMITS.keySet()) {
+			if(count(position) == limitFor(position)) {
+				bench.add(position);
+			}
+		}
+		return bench;
+	}
+
+	public int benchCount() {
+		return benchPositions().size();
+	}
+
+	private static String checkKnown(String position) {
+		String normalised = position == null ? null : position.toLowerCase();
+		if(normalised == null || !LIMITS.containsKey(normalised)) {
+			throw new UnknownPositionException(position);
+		}
+		return normalised;
+	}
+
+	@Override
+	public String toString() {
+		return counts.toString();
+	}
+}

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -14,7 +14,6 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import net.dflmngr.exceptions.MissingGlobalConfig;
-import net.dflmngr.exceptions.UnknownPositionException;
 import net.dflmngr.model.entity.AflFixture;
 import net.dflmngr.model.entity.DflPlayer;
 import net.dflmngr.model.entity.DflPlayerPredictedScores;
@@ -199,7 +198,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 		Map<Integer, Integer> scores = new HashMap<>();
 
 		Map<Integer, String> playerPositions = new HashMap<>();
-		List<String> benchPositions = new ArrayList<>();
+		PositionCounts positionCounts = new PositionCounts();
 
 		List<String> playedTeams = new ArrayList<>();
 		int aflRound = 0;
@@ -221,13 +220,6 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			loggerUtils.log("debug", "Played teams for AFL round={} teams={}", aflRound, playedTeams);
 		}
 
-		int ffCount = 0;
-		int fwdCount = 0;
-		int midCount = 0;
-		int defCount = 0;
-		int fbCount = 0;
-		int rckCount = 0;
-
 		for(DflSelectedPlayer selectedPlayer : selectedTeam) {
 			DflPlayerScoresPK pk = new DflPlayerScoresPK();
 			pk.setPlayerId(selectedPlayer.getPlayerId());
@@ -240,27 +232,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 			playerPositions.put(selectedPlayer.getPlayerId(), position);
 
 			if(selectedPlayer.isEmergency() == 0) {
-				switch(position) {
-					case "ff" :
-						ffCount++;
-						break;
-					case "fwd" :
-						fwdCount++;
-						break;
-					case "rck" :
-						rckCount++;
-						break;
-					case "mid" :
-						midCount++;
-						break;
-					case "def" :
-						defCount++;
-						break;
-					case "fb" :
-						fbCount++;
-						break;
-					default: throw new UnknownPositionException(position);
-				}
+				positionCounts.increment(position);
 			}
 
 			selectedPlayer.setReplacementInd(null);
@@ -329,26 +301,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 		loggerUtils.log("info", "DNPs={} -- Size:{}", dnpPlayers, dnpPlayers.size());
 		loggerUtils.log("info", "Emergencies={} -- Size:{}", emergencies, emergencies.size());
 
-		if(ffCount == 2) {
-			benchPositions.add("ff");
-		}
-		if(fwdCount == 6) {
-			benchPositions.add("fwd");
-		}
-		if(midCount == 6) {
-			benchPositions.add("mid");
-		}
-		if(defCount == 6) {
-			benchPositions.add("def");
-		}
-		if(fbCount == 2) {
-			benchPositions.add("fb");
-		}
-		if(rckCount == 2) {
-			benchPositions.add("rck");
-		}
-
-		loggerUtils.log("info", "Bench positions={}", benchPositions);
+		loggerUtils.log("info", "Bench positions={}", positionCounts.benchPositions());
 
 		if(!dnpPlayers.isEmpty()) {
 			if(emergencies.isEmpty()) {
@@ -402,91 +355,18 @@ public class ScoresCalculatorHandler extends BaseHandler {
 
 						boolean allowEmg = false;
 
-						switch(dnpPosition) {
-							case "ff" :
-								if(ffCount > 1) {
-									ffCount--;
-									allowEmg = true;
-								}
-								break;
-							case "fwd" :
-								if(fwdCount > 5) {
-									fwdCount--;
-									allowEmg = true;
-								}
-								break;
-							case "rck" :
-								if(rckCount > 1) {
-									rckCount--;
-									allowEmg = true;
-								}
-								break;
-							case "mid" :
-								if(midCount > 5) {
-									midCount--;
-									allowEmg = true;
-								}
-								break;
-							case "def" :
-								if(defCount > 5) {
-									defCount--;
-									allowEmg = true;
-								}
-								break;
-							case "fb" :
-								if(fbCount > 1) {
-									fbCount--;
-									allowEmg = true;
-								}
-								break;
-							default: throw new UnknownPositionException(dnpPosition);
+						if(positionCounts.isFull(dnpPosition)) {
+							positionCounts.decrement(dnpPosition);
+							allowEmg = true;
 						}
 
 						if(allowEmg) {
 							for(DflSelectedPlayer emergency : emergencies) {
 								String emgPosition = playerPositions.get(emergency.getPlayerId());
 
-								switch(emgPosition) {
-									case "ff":
-										if(ffCount < 2) {
-											replacement = emergency;
-											ffCount++;
-										}
-										break;
-									case "fwd":
-										if(fwdCount < 6) {
-											replacement = emergency;
-											fwdCount++;
-										}
-										break;
-									case "rck":
-										if(rckCount < 2) {
-											replacement = emergency;
-											rckCount++;
-										}
-										break;
-									case "mid":
-										if(midCount < 6) {
-											replacement = emergency;
-											midCount++;
-										}
-										break;
-									case "fb":
-										if(fbCount < 2) {
-											replacement = emergency;
-											fbCount++;
-										}
-										break;
-									case "def":
-										if(defCount < 6) {
-											replacement = emergency;
-											defCount++;
-										}
-										break;
-									default: throw new UnknownPositionException(emgPosition);
-								}
-
-								if(replacement != null) {
+								if(positionCounts.hasRoom(emgPosition)) {
+									replacement = emergency;
+									positionCounts.increment(emgPosition);
 									break;
 								}
 							}

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -1,10 +1,10 @@
 package net.dflmngr.handlers;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.dflmngr.exceptions.UnknownPositionException;
 import net.dflmngr.model.entity.DflPlayer;
 import net.dflmngr.model.entity.DflRoundInfo;
 import net.dflmngr.model.entity.DflRoundMapping;
@@ -464,20 +464,8 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		validationResult.lockedOut = false;
 		validationResult.teamPlayerCheckOk = true;
 
-		int ffCount = 0;
-		int fwdCount = 0;
-		int midCount = 0;
-		int defCount = 0;
-		int fbCount = 0;
-		int rckCount = 0;
-		int benchCount = 0;
-
-		List<DflPlayer> ffPlayers = new ArrayList<>();
-		List<DflPlayer> fwdPlayers = new ArrayList<>();
-		List<DflPlayer> midPlayers = new ArrayList<>();
-		List<DflPlayer> defPlayers = new ArrayList<>();
-		List<DflPlayer> fbPlayers = new ArrayList<>();
-		List<DflPlayer> rckPlayers = new ArrayList<>();
+		PositionCounts positionCounts = new PositionCounts();
+		Map<String, List<DflPlayer>> playersByPosition = new HashMap<>();
 
 		List<String> emergencyPositions = new ArrayList<>();
 		List<DflPlayer> emgPlayers = new ArrayList<>();
@@ -495,85 +483,42 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 			String position = player.getPosition().toLowerCase();
 
 			if(selectedPlayer.isEmergency() == 0) {
-				switch(position) {
-					case "ff" :
-						ffCount++;
-						ffPlayers.add(player);
-						break;
-					case "fwd" :
-						fwdCount++;
-						fwdPlayers.add(player);
-						break;
-					case "rck" :
-						rckCount++;
-						rckPlayers.add(player);
-						break;
-					case "mid" :
-						midCount++;
-						midPlayers.add(player);
-						break;
-					case "def" :
-						defCount++;
-						defPlayers.add(player);
-						break;
-					case "fb" :
-						fbCount++;
-						fbPlayers.add(player);
-						break;
-					default: throw new UnknownPositionException(position);
-				}
+				positionCounts.increment(position);
+				playersByPosition.computeIfAbsent(position, k -> new ArrayList<>()).add(player);
 			} else {
 				emergencyPositions.add(position);
 				emgPlayers.add(player);
 			}
 		}
 
-		loggerUtils.log("info", "Position counts: ffCount={}; fwdCount={}; midCount={}; defCount={}; fbCount={}; rckCount={}, emergencyPositions={};",
-						ffCount, fwdCount, midCount, defCount, fbCount, rckCount, emergencyPositions);
+		loggerUtils.log("info", "Position counts: {}, emergencyPositions={};", positionCounts, emergencyPositions);
 
-		if(ffCount <= 2) {
+		if(!positionCounts.overLimit("ff")) {
 			validationResult.ffCheckOk = true;
-			validationResult.ffPlayers = ffPlayers;
+			validationResult.ffPlayers = playersByPosition.getOrDefault("ff", new ArrayList<>());
 		}
-		if(fwdCount <= 6) {
+		if(!positionCounts.overLimit("fwd")) {
 			validationResult.fwdCheckOk = true;
-			validationResult.fwdPlayers = fwdPlayers;
+			validationResult.fwdPlayers = playersByPosition.getOrDefault("fwd", new ArrayList<>());
 		}
-		if(midCount <= 6) {
+		if(!positionCounts.overLimit("mid")) {
 			validationResult.midCheckOk = true;
-			validationResult.midPlayers = midPlayers;
+			validationResult.midPlayers = playersByPosition.getOrDefault("mid", new ArrayList<>());
 		}
-		if(defCount <= 6) {
+		if(!positionCounts.overLimit("def")) {
 			validationResult.defCheckOk = true;
-			validationResult.defPlayers = defPlayers;
+			validationResult.defPlayers = playersByPosition.getOrDefault("def", new ArrayList<>());
 		}
-		if(fbCount <= 2) {
+		if(!positionCounts.overLimit("fb")) {
 			validationResult.fbCheckOk = true;
-			validationResult.fbPlayers = fbPlayers;
+			validationResult.fbPlayers = playersByPosition.getOrDefault("fb", new ArrayList<>());
 		}
-		if(rckCount <= 2) {
+		if(!positionCounts.overLimit("rck")) {
 			validationResult.rckCheckOk = true;
-			validationResult.rckPlayers = rckPlayers;
+			validationResult.rckPlayers = playersByPosition.getOrDefault("rck", new ArrayList<>());
 		}
 
-		if(ffCount == 2) {
-			benchCount++;
-		}
-		if(fwdCount == 6) {
-			benchCount++;
-		}
-		if(midCount == 6) {
-			benchCount++;
-		}
-		if(defCount == 6) {
-			benchCount++;
-		}
-		if(fbCount == 2) {
-			benchCount++;
-		}
-		if(rckCount == 2) {
-			benchCount++;
-		}
+		int benchCount = positionCounts.benchCount();
 
 		loggerUtils.log("info", "Bench count={};", benchCount);
 
@@ -582,44 +527,15 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		}
 
 		for(String position : emergencyPositions) {
-			switch(position) {
-				case "ff" :
-					ffCount++;
-					break;
-				case "fwd" :
-					fwdCount++;
-					break;
-				case "rck" :
-					rckCount++;
-					break;
-				case "mid" :
-					midCount++;
-					break;
-				case "def" :
-					defCount++;
-					break;
-				case "fb" :
-					fbCount++;
-					break;
-				default: throw new UnknownPositionException(position);
-			}
+			positionCounts.increment(position);
 		}
 
-		if(ffCount > 2 || fwdCount > 6 || midCount > 6 || defCount > 6 || fbCount > 2 || rckCount > 2) {
+		if(positionCounts.anyOverLimit()) {
 			List<Double> emgs = validationResult.getEmergencies();
 			for(DflPlayer player : emgPlayers) {
 				String pos = player.getPosition().toLowerCase();
-				boolean invalid = switch(pos) {
-					case "ff"  -> ffCount > 2;
-					case "fwd" -> fwdCount > 6;
-					case "rck" -> rckCount > 2;
-					case "mid" -> midCount > 6;
-					case "def" -> defCount > 6;
-					case "fb"  -> fbCount > 2;
-					default -> throw new UnknownPositionException(pos);
-				};
 
-				if(invalid) {
+				if(positionCounts.overLimit(pos)) {
 					validationResult.emergencyWarning = true;
 					loggerUtils.log("info", "Invalid emergency, player={};", player);
 

--- a/src/test/java/net/dflmngr/handlers/PositionCountsTest.java
+++ b/src/test/java/net/dflmngr/handlers/PositionCountsTest.java
@@ -1,0 +1,98 @@
+package net.dflmngr.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.dflmngr.exceptions.UnknownPositionException;
+
+class PositionCountsTest {
+
+	private PositionCounts counts;
+
+	@BeforeEach
+	void setUp() {
+		counts = new PositionCounts();
+	}
+
+	@Test
+	void limitFor_shouldReturnPositionLimits() {
+		assertEquals(2, PositionCounts.limitFor("ff"));
+		assertEquals(6, PositionCounts.limitFor("fwd"));
+		assertEquals(2, PositionCounts.limitFor("rck"));
+		assertEquals(6, PositionCounts.limitFor("mid"));
+		assertEquals(6, PositionCounts.limitFor("def"));
+		assertEquals(2, PositionCounts.limitFor("fb"));
+	}
+
+	@Test
+	void unknownPosition_shouldThrow() {
+		assertThrows(UnknownPositionException.class, () -> PositionCounts.limitFor("goalie"));
+		assertThrows(UnknownPositionException.class, () -> counts.increment("goalie"));
+		assertThrows(UnknownPositionException.class, () -> PositionCounts.limitFor(null));
+	}
+
+	@Test
+	void positions_shouldBeCaseInsensitive() {
+		counts.increment("FWD");
+		assertEquals(1, counts.count("fwd"));
+		assertEquals(2, PositionCounts.limitFor("FF"));
+	}
+
+	@Test
+	void incrementAndDecrement_shouldTrackCounts() {
+		assertEquals(0, counts.count("mid"));
+		counts.increment("mid");
+		counts.increment("mid");
+		assertEquals(2, counts.count("mid"));
+		counts.decrement("mid");
+		assertEquals(1, counts.count("mid"));
+	}
+
+	@Test
+	void hasRoomAndIsFull_shouldReflectLimit() {
+		assertTrue(counts.hasRoom("ff"));
+		assertFalse(counts.isFull("ff"));
+
+		counts.increment("ff");
+		counts.increment("ff");
+
+		assertFalse(counts.hasRoom("ff"));
+		assertTrue(counts.isFull("ff"));
+		assertFalse(counts.overLimit("ff"));
+
+		counts.increment("ff");
+		assertTrue(counts.overLimit("ff"));
+		assertTrue(counts.anyOverLimit());
+	}
+
+	@Test
+	void benchPositions_shouldListPositionsExactlyAtLimit() {
+		counts.increment("ff");
+		counts.increment("ff");
+		for (int i = 0; i < 6; i++) {
+			counts.increment("mid");
+		}
+		counts.increment("fwd");
+
+		assertEquals(List.of("ff", "mid"), counts.benchPositions());
+		assertEquals(2, counts.benchCount());
+
+		// over the limit is no longer "exactly at limit"
+		counts.increment("ff");
+		assertEquals(List.of("mid"), counts.benchPositions());
+	}
+
+	@Test
+	void anyOverLimit_shouldBeFalseWhenAllWithinLimits() {
+		counts.increment("fwd");
+		counts.increment("def");
+		assertFalse(counts.anyOverLimit());
+	}
+}


### PR DESCRIPTION
## Summary

First of four refactoring PRs (merge order: this one first).

The ff/fwd/mid/def/fb/rck switch statement — with the position limits 2/6/6/6/2/2 hardcoded in every copy — appeared **six times** across `ScoresCalculatorHandler` and `SelectedTeamValidationHandler`, plus two copies of the bench-slot counting logic. This is exactly the duplication that let the `def`-only leftover condition (#257) survive unnoticed.

`PositionCounts` now owns the counts, the limits, and the bench calculation (`increment`/`decrement`/`hasRoom`/`isFull`/`overLimit`/`benchPositions`), validating position names centrally (`UnknownPositionException`, case-insensitive).

Net effect: ~230 lines removed; Sonar cognitive complexity drops from 221→120 (`calculateTeamScore`) and 42→30 (`validateTeam`). No behavior change intended.

## Tests

- New `PositionCountsTest` covering limits, counting, room/full/over-limit, bench positions, unknown-position errors, case-insensitivity.
- Full suite: 146 tests, 0 failures (existing handler regression tests unchanged and green).