### PR TITLE
Centralise handler service lifecycle and email recipient resolution

### DIFF
--- a/src/main/java/net/dflmngr/handlers/AdamGoodesHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AdamGoodesHandler.java
@@ -37,9 +37,9 @@ public class AdamGoodesHandler extends BaseHandler {
 		medalStandings = new ArrayList<>();
 		topFirstYears = new ArrayList<>();
 
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
 	}
 
 	public void execute(int round) {
@@ -57,12 +57,11 @@ public class AdamGoodesHandler extends BaseHandler {
 			
 			calculateStandings(round, adamGoodesEligible, playerScores);
 			
-			dflPlayerService.close();
-			dflPlayerScoresService.close();
-			dflSelectedTeamService.close();
 	
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in AdamGoodesHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/AflFixtureHtmlHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflFixtureHtmlHandler.java
@@ -36,8 +36,8 @@ public class AflFixtureHtmlHandler extends BaseHandler {
     public AflFixtureHtmlHandler() {
         super("AflFixtureLoader");
 
-        globalsService = serviceFactory.createGlobalsService();
-        aflTeamService = serviceFactory.createAflTeamService();
+        globalsService = manage(serviceFactory.createGlobalsService());
+        aflTeamService = manage(serviceFactory.createAflTeamService());
 
         currentYear = globalsService.getCurrentYear();
         defaultTimezone = globalsService.getGroundTimeZone("default");

--- a/src/main/java/net/dflmngr/handlers/AflFixtureLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflFixtureLoaderHandler.java
@@ -25,9 +25,9 @@ public class AflFixtureLoaderHandler extends BaseHandler {
 		super("AflFixtureLoader");
 
 		try {
-			globalsService = serviceFactory.createGlobalsService();
-			aflFixtureService = serviceFactory.createAflFixtureService();
-			aflTeamService = serviceFactory.createAflTeamService();
+			globalsService = manage(serviceFactory.createGlobalsService());
+			aflFixtureService = manage(serviceFactory.createAflFixtureService());
+			aflTeamService = manage(serviceFactory.createAflTeamService());
 			aflFixtureHtmlHandler = new AflFixtureHtmlHandler();
 			ensureLoggingConfigured();
 		} catch (Exception ex) {
@@ -36,6 +36,14 @@ public class AflFixtureLoaderHandler extends BaseHandler {
 	}
 	
 	public void execute(List<Integer> aflRounds) {
+		try {
+			doExecute(aflRounds);
+		} finally {
+			closeServices();
+		}
+	}
+
+	private void doExecute(List<Integer> aflRounds) {
 
 		loggerUtils.log("info", "Executing AflFixtureLoader for rounds: {}", aflRounds);
 		

--- a/src/main/java/net/dflmngr/handlers/AflGameCompletionCheckerHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflGameCompletionCheckerHandler.java
@@ -33,8 +33,8 @@ public class AflGameCompletionCheckerHandler extends BaseHandler {
 
 	public AflGameCompletionCheckerHandler() {
 		super("AflGameCompletionChecker");
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		globalsService = serviceFactory.createGlobalsService();
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		globalsService = manage(serviceFactory.createGlobalsService());
 	}
 
 	public void configureLogging(String logfile) {
@@ -82,13 +82,13 @@ public class AflGameCompletionCheckerHandler extends BaseHandler {
 				loggerUtils.log("info", "All started AFL fixtures are complete");
 			}
 
-			aflFixtureService.close();
-			globalsService.close();
 
 			loggerUtils.log("info", "AflGameCompletionChecker completed");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in AflGameCompletionCheckerHandler.execute()", ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHandler.java
@@ -29,11 +29,11 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 		super("AflPlayerLoader");
 
 		try {
-			aflTeamService = serviceFactory.createAflTeamService();
-			aflPlayerService = serviceFactory.createAflPlayerService();
-			dflPlayerService = serviceFactory.createDflPlayerService();
-			globalsService = serviceFactory.createGlobalsService();
-			dflUnmatchedPlayerService = serviceFactory.createDflUnmatchedPlayerService();
+			aflTeamService = manage(serviceFactory.createAflTeamService());
+			aflPlayerService = manage(serviceFactory.createAflPlayerService());
+			dflPlayerService = manage(serviceFactory.createDflPlayerService());
+			globalsService = manage(serviceFactory.createGlobalsService());
+			dflUnmatchedPlayerService = manage(serviceFactory.createDflUnmatchedPlayerService());
 
 			ensureLoggingConfigured();
 		} catch (Exception ex) {
@@ -55,6 +55,8 @@ public class AflPlayerLoaderHandler extends BaseHandler {
 			loggerUtils.log("info", "AflPlayerLoader Complete");
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in AflPlayerLoaderHandler.execute()", ex);
+		} finally {
+			closeServices();
 		}
 
 	}

--- a/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHtmlHandler.java
+++ b/src/main/java/net/dflmngr/handlers/AflPlayerLoaderHtmlHandler.java
@@ -29,7 +29,7 @@ public class AflPlayerLoaderHtmlHandler extends BaseHandler {
 
 	public AflPlayerLoaderHtmlHandler() {
 		super("AflPlayerLoader");
-		globalsService = serviceFactory.createGlobalsService();
+		globalsService = manage(serviceFactory.createGlobalsService());
 		ensureLoggingConfigured();
 	}
 

--- a/src/main/java/net/dflmngr/handlers/BaseHandler.java
+++ b/src/main/java/net/dflmngr/handlers/BaseHandler.java
@@ -1,8 +1,12 @@
 package net.dflmngr.handlers;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.slf4j.MDC;
 
 import net.dflmngr.logging.LoggingUtils;
+import net.dflmngr.model.service.GenericService;
 import net.dflmngr.service.ServiceFactory;
 
 /**
@@ -24,9 +28,35 @@ public abstract class BaseHandler {
 	protected String loggerName;
 	protected String logfile;
 
+	private final List<GenericService<?, ?>> managedServices = new ArrayList<>();
+
 	protected BaseHandler(String defaultLogfile) {
 		this.defaultLogfile = defaultLogfile;
 		this.serviceFactory = ServiceFactory.getInstance();
+	}
+
+	/**
+	 * Register a service so closeServices() will close it. Wrap service
+	 * creation in the constructor: manage(serviceFactory.createXxx()).
+	 */
+	protected <S extends GenericService<?, ?>> S manage(S service) {
+		managedServices.add(service);
+		return service;
+	}
+
+	/**
+	 * Close all managed services. Call from a finally block in execute().
+	 */
+	protected void closeServices() {
+		for (GenericService<?, ?> service : managedServices) {
+			try {
+				service.close();
+			} catch (Exception ex) {
+				if (loggerUtils != null) {
+					loggerUtils.log("warn", "Error closing service: {}", ex.getMessage());
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/net/dflmngr/handlers/Best22Handler.java
+++ b/src/main/java/net/dflmngr/handlers/Best22Handler.java
@@ -31,9 +31,9 @@ public class Best22Handler extends BaseHandler {
 
 	public Best22Handler() {
 		super("Best22Handler");
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		dflBest22Service = serviceFactory.createDflBest22Service();
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		dflBest22Service = manage(serviceFactory.createDflBest22Service());
 	}
 
 	public void execute(int round) {
@@ -45,12 +45,13 @@ public class Best22Handler extends BaseHandler {
 			
 			calculateBest22(round);
 			
-			dflPlayerScoresService.close();
 			
 			loggerUtils.log("info", "Best22Handler complete");
 			
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in Best22Handler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
+++ b/src/main/java/net/dflmngr/handlers/CallumChambersHandler.java
@@ -37,10 +37,10 @@ public class CallumChambersHandler extends BaseHandler {
 		super("CallumChambersHandler");
 		medalStandings = new ArrayList<>();
 
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		globalsService = serviceFactory.createGlobalsService();
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		globalsService = manage(serviceFactory.createGlobalsService());
 	}
 
 	public void execute(int round) {
@@ -57,13 +57,11 @@ public class CallumChambersHandler extends BaseHandler {
 
 			calculateStandings(round, players, playerScores);
 
-			dflPlayerService.close();
-			dflPlayerScoresService.close();
-			dflTeamPlayerService.close();
-			globalsService.close();
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in CallumChambersHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/DflFixtureGeneratorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/DflFixtureGeneratorHandler.java
@@ -15,8 +15,8 @@ public class DflFixtureGeneratorHandler extends BaseHandler {
 
 	public DflFixtureGeneratorHandler() {
 		super("DflFixtureGeneratorHandler");
-		globalsService = serviceFactory.createGlobalsService();
-		dflFixtureService = serviceFactory.createDflFixtureService();
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflFixtureService = manage(serviceFactory.createDflFixtureService());
 	}
 
 	public void execute() {
@@ -33,6 +33,8 @@ public class DflFixtureGeneratorHandler extends BaseHandler {
 			
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in DflFixtureGeneratorHandler.execute()", ex);
+		} finally {
+			closeServices();
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/DflRoundInfoCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/DflRoundInfoCalculatorHandler.java
@@ -48,10 +48,10 @@ public class DflRoundInfoCalculatorHandler extends BaseHandler {
 		super("DflRoundInfoCalculatorHandler");
 
 		try{
-			globalsService = serviceFactory.createGlobalsService();
-			aflFixtureService = serviceFactory.createAflFixtureService();
-			dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-			aflTeamService = serviceFactory.createAflTeamService();
+			globalsService = manage(serviceFactory.createGlobalsService());
+			aflFixtureService = manage(serviceFactory.createAflFixtureService());
+			dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+			aflTeamService = manage(serviceFactory.createAflTeamService());
 
 			String defaultTimezone = globalsService.getGroundTimeZone("default");
 			lockoutFormat.setTimeZone(TimeZone.getTimeZone(defaultTimezone));
@@ -91,6 +91,8 @@ public class DflRoundInfoCalculatorHandler extends BaseHandler {
 			loggerUtils.log("info", "DflRoundInfoCalculator Complete");
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in DflRoundInfoCalculatorHandler.execute()", ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -75,9 +75,9 @@ public class EmailSelectionsHandler extends BaseHandler {
 
 	public EmailSelectionsHandler() {
 		super("Selections");
-		globalsService = serviceFactory.createGlobalsService();
-		dflTeamService = serviceFactory.createDflTeamService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
 	}
 
 	public void execute() {
@@ -124,9 +124,7 @@ public class EmailSelectionsHandler extends BaseHandler {
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in EmailSelectionsHandler.execute()", ex);
 		} finally {
-			globalsService.close();
-			dflTeamService.close();
-			dflTeamPlayerService.close();
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/EndRoundHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EndRoundHandler.java
@@ -67,18 +67,18 @@ public class EndRoundHandler extends BaseHandler {
 
 	public EndRoundHandler() {
 		super("EndRound");
-		dflMatthewAllenService = serviceFactory.createDflMatthewAllenService();
-		globalsService = serviceFactory.createGlobalsService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		dflTeamService = serviceFactory.createDflTeamService();
-		dflBest22Service = serviceFactory.createDflBest22Service();
-		dflLadderService = serviceFactory.createDflLadderService();
-		dflFixtureService = serviceFactory.createDflFixtureService();
-		dflTeamScoresService = serviceFactory.createDflTeamScoresService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		insAndOutsService = serviceFactory.createInsAndOutsService();
+		dflMatthewAllenService = manage(serviceFactory.createDflMatthewAllenService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		dflBest22Service = manage(serviceFactory.createDflBest22Service());
+		dflLadderService = manage(serviceFactory.createDflLadderService());
+		dflFixtureService = manage(serviceFactory.createDflFixtureService());
+		dflTeamScoresService = manage(serviceFactory.createDflTeamScoresService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		insAndOutsService = manage(serviceFactory.createInsAndOutsService());
 	}
 
 	public void execute(int round, String emailOverride) {
@@ -145,23 +145,13 @@ public class EndRoundHandler extends BaseHandler {
 
 			globalsService.setCurrentRound(round + 1);
 
-			dflMatthewAllenService.close();
-			globalsService.close();
-			dflPlayerService.close();
-			dflTeamPlayerService.close();
-			dflTeamService.close();
-			dflBest22Service.close();
-			dflLadderService.close();
-			dflFixtureService.close();
-			dflTeamScoresService.close();
-			dflSelectedTeamService.close();
-			dflRoundInfoService.close();
-			insAndOutsService.close();
 
 			loggerUtils.log("info", "End round completed");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in EndRoundHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 
 	}
@@ -925,16 +915,7 @@ public class EndRoundHandler extends BaseHandler {
 
 		String dflMngrEmail = globalsService.getEmailConfig().get("dflmngrEmailAddr");
 
-		List<String> to = new ArrayList<>();
-
-		if (emailOverride != null && !emailOverride.equals("")) {
-			to.add(emailOverride);
-		} else {
-			List<DflTeam> teams = dflTeamService.findAll();
-			for (DflTeam team : teams) {
-				to.add(team.getCoachEmail());
-			}
-		}
+		List<String> to = EmailUtils.resolveRecipients(emailOverride, EmailUtils.coachEmails(dflTeamService.findAll()));
 
 		loggerUtils.log("info", "Emailing to={};", to);
 		EmailUtils.sendTextEmail(to, dflMngrEmail, subject, body, null);

--- a/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/LadderCalculatorHandler.java
@@ -28,12 +28,12 @@ public class LadderCalculatorHandler extends BaseHandler {
 
 	public LadderCalculatorHandler() {
 		super("RoundProgress");
-		dflLadderService = serviceFactory.createDflLadderService();
-		dflFixtureService = serviceFactory.createDflFixtureService();
-		dflTeamScoresService = serviceFactory.createDflTeamScoresService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflPlayerPredictedScoresService = serviceFactory.createDflPlayerPredictedScoresService();
+		dflLadderService = manage(serviceFactory.createDflLadderService());
+		dflFixtureService = manage(serviceFactory.createDflFixtureService());
+		dflTeamScoresService = manage(serviceFactory.createDflTeamScoresService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflPlayerPredictedScoresService = manage(serviceFactory.createDflPlayerPredictedScoresService());
 	}
 
 	public void configureLogging(String logfile) {
@@ -53,12 +53,7 @@ public class LadderCalculatorHandler extends BaseHandler {
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in LadderCalculatorHandler.execute(), round=" + round, ex);
 		} finally {
-			dflLadderService.close();
-			dflFixtureService.close();
-			dflTeamScoresService.close();
-			dflSelectedTeamService.close();
-			dflPlayerScoresService.close();
-			dflPlayerPredictedScoresService.close();
+			closeServices();
 		}
 	}
 		

--- a/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
+++ b/src/main/java/net/dflmngr/handlers/MatthewAllenHandler.java
@@ -34,11 +34,11 @@ public class MatthewAllenHandler extends BaseHandler {
 
 	public MatthewAllenHandler() {
 		super("RoundProgress");
-		dflFixtureService = serviceFactory.createDflFixtureService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflMatthewAllenService = serviceFactory.createDflMatthewAllenService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
+		dflFixtureService = manage(serviceFactory.createDflFixtureService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflMatthewAllenService = manage(serviceFactory.createDflMatthewAllenService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
 	}
 
 	public void execute(int round) {
@@ -61,6 +61,8 @@ public class MatthewAllenHandler extends BaseHandler {
 			
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in MatthewAllenHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 	

--- a/src/main/java/net/dflmngr/handlers/PreSeasonStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/PreSeasonStatsHandler.java
@@ -27,12 +27,20 @@ public class PreSeasonStatsHandler extends BaseHandler {
 
 	public PreSeasonStatsHandler() {
 		super("PreSeasonStats");
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		globalsService = serviceFactory.createGlobalsService();
-		dflPreseasonScoresService = serviceFactory.createDflPreseasonScoresService();
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflPreseasonScoresService = manage(serviceFactory.createDflPreseasonScoresService());
 	}
 
 	public void execute(int round) {
+		try {
+			doExecute(round);
+		} finally {
+			closeServices();
+		}
+	}
+
+	private void doExecute(int round) {
 
 		ensureLoggingConfigured();
 		

--- a/src/main/java/net/dflmngr/handlers/PredictionHandler.java
+++ b/src/main/java/net/dflmngr/handlers/PredictionHandler.java
@@ -34,11 +34,11 @@ public class PredictionHandler extends BaseHandler {
 
 	public PredictionHandler() {
 		super("Predictions");
-		dflPlayerPredictedScoresService = serviceFactory.createDflPlayerPredictedScoresService();
-		dflTeamPredictedScoresService = serviceFactory.createDflTeamPredictedScoresService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflTeamService = serviceFactory.createDflTeamService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
+		dflPlayerPredictedScoresService = manage(serviceFactory.createDflPlayerPredictedScoresService());
+		dflTeamPredictedScoresService = manage(serviceFactory.createDflTeamPredictedScoresService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
 	}
 
 	public void execute(int round, String teamCode, boolean doPlayers) {
@@ -56,14 +56,11 @@ public class PredictionHandler extends BaseHandler {
 
 			loggerUtils.log("info", "PredictionHandler completed");
 
-			dflPlayerPredictedScoresService.close();
-			dflTeamPredictedScoresService.close();
-			dflPlayerScoresService.close();
-			dflTeamService.close();
-			dflSelectedTeamService.close();
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in PredictionHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/RawPlayerStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/RawPlayerStatsHandler.java
@@ -34,11 +34,11 @@ public class RawPlayerStatsHandler extends BaseHandler {
 
 	public RawPlayerStatsHandler() {
 		super("RawPlayerStatsHandler");
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		globalsService = serviceFactory.createGlobalsService();
-		statsRoundPlayerStatsService = serviceFactory.createStatsRoundPlayerStatsService();
-		rawPlayerStatsService = serviceFactory.createRawPlayerStatsService();
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		statsRoundPlayerStatsService = manage(serviceFactory.createStatsRoundPlayerStatsService());
+		rawPlayerStatsService = manage(serviceFactory.createRawPlayerStatsService());
 	}
 
 	public void configureLogging(String logfile) {
@@ -62,16 +62,13 @@ public class RawPlayerStatsHandler extends BaseHandler {
 				handleWithStatRounds(round, scrapeAll);
 			}
 
-			dflRoundInfoService.close();
-			aflFixtureService.close();
-			globalsService.close();
-			statsRoundPlayerStatsService.close();
-			rawPlayerStatsService.close();
 
 			loggerUtils.log("info", "Player stats downloaded");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in RawPlayerStatsHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/ResultsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ResultsHandler.java
@@ -28,9 +28,9 @@ public class ResultsHandler extends BaseHandler {
 
 	public ResultsHandler() {
 		super("RoundProgress");
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		globalsService = serviceFactory.createGlobalsService();
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		globalsService = manage(serviceFactory.createGlobalsService());
 	}
 
 	public void configureLogging(String logfile) {
@@ -64,14 +64,13 @@ public class ResultsHandler extends BaseHandler {
 				loggerUtils.log("info", "Handled round={} ....", round);
 			}
 
-			aflFixtureService.close();
-			dflRoundInfoService.close();
-			globalsService.close();
 			
 			loggerUtils.log("info", "ResultsHandler complete");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in ResultsHandler.execute(), inputRound=" + inputRound, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
+++ b/src/main/java/net/dflmngr/handlers/ScoresCalculatorHandler.java
@@ -54,17 +54,17 @@ public class ScoresCalculatorHandler extends BaseHandler {
 
 	public ScoresCalculatorHandler() {
 		super("RoundProgress");
-		rawPlayerStatsService = serviceFactory.createRawPlayerStatsService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		dflPlayerScoresService = serviceFactory.createDflPlayerScoresService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflTeamService = serviceFactory.createDflTeamService();
-		dflTeamScoresService = serviceFactory.createDflTeamScoresService();
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		globalsService = serviceFactory.createGlobalsService();
-		dflPlayerPredictedScoresService = serviceFactory.createDflPlayerPredictedScoresService();
+		rawPlayerStatsService = manage(serviceFactory.createRawPlayerStatsService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		dflPlayerScoresService = manage(serviceFactory.createDflPlayerScoresService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		dflTeamScoresService = manage(serviceFactory.createDflTeamScoresService());
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflPlayerPredictedScoresService = manage(serviceFactory.createDflPlayerPredictedScoresService());
 	}
 
 	public void configureLogging(String logfile) {
@@ -92,17 +92,7 @@ public class ScoresCalculatorHandler extends BaseHandler {
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in ScoresCalculatorHandler.execute(), round=" + round, ex);
 		} finally {
-			rawPlayerStatsService.close();
-			dflPlayerService.close();
-			dflTeamPlayerService.close();
-			dflPlayerScoresService.close();
-			dflSelectedTeamService.close();
-			dflTeamService.close();
-			dflTeamScoresService.close();
-			dflRoundInfoService.close();
-			aflFixtureService.close();
-			globalsService.close();
-			dflPlayerPredictedScoresService.close();
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -34,14 +34,14 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 
 	public SelectedTeamValidationHandler() {
 		super("SelectedTeamValidationHandler");
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		globalsService = serviceFactory.createGlobalsService();
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		dflEarlyInsAndOutsService = serviceFactory.createDflEarlyInsAndOutsService();
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		dflSelectionIdsService = serviceFactory.createDflSelectionIdsService();
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		dflEarlyInsAndOutsService = manage(serviceFactory.createDflEarlyInsAndOutsService());
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		dflSelectionIdsService = manage(serviceFactory.createDflSelectionIdsService());
 	}
 
 	public SelectedTeamValidation execute(int round, String teamCode, Map<String, List<Integer>> insAndOuts, List<Double> emergencies, String selectionId) {
@@ -80,14 +80,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 				validationResult.setTeamCode(teamCode);
 			}
 		} finally {
-			dflSelectedTeamService.close();
-			dflTeamPlayerService.close();
-			dflPlayerService.close();
-			globalsService.close();
-			dflRoundInfoService.close();
-			dflEarlyInsAndOutsService.close();
-			aflFixtureService.close();
-			dflSelectionIdsService.close();
+			closeServices();
 		}
 
 		return validationResult;

--- a/src/main/java/net/dflmngr/handlers/SelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectionsHandler.java
@@ -30,10 +30,10 @@ public class SelectionsHandler extends BaseHandler {
 
 	public SelectionsHandler() {
 		super("SelectionsHandler");
-		dflTeamService = serviceFactory.createDflTeamService();
-		insAndOutsService = serviceFactory.createInsAndOutsService();
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		insAndOutsService = manage(serviceFactory.createInsAndOutsService());
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
 	}
 
 	public void execute(int round) {
@@ -50,15 +50,13 @@ public class SelectionsHandler extends BaseHandler {
 				createTeamSelections(round, team.getTeamCode(), insAndOuts);
 			}
 
-			dflTeamService.close();
-			insAndOutsService.close();
-			dflSelectedTeamService.close();
-			dflTeamPlayerService.close();
 
 			loggerUtils.log("info", "Team selections created");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in SelectionsHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/StartRoundHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StartRoundHandler.java
@@ -42,15 +42,15 @@ public class StartRoundHandler extends BaseHandler {
 
 	public StartRoundHandler() {
 		super("StartRound");
-		dflTeamService = serviceFactory.createDflTeamService();
-		globalsService = serviceFactory.createGlobalsService();
-		dflFixtureService = serviceFactory.createDflFixtureService();
-		dflTeamPredictedScoresService = serviceFactory.createDflTeamPredictedScoresService();
-		dflPlayerService = serviceFactory.createDflPlayerService();
-		insAndOutsService = serviceFactory.createInsAndOutsService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		aflFixtureService = serviceFactory.createAflFixtureService();
+		dflTeamService = manage(serviceFactory.createDflTeamService());
+		globalsService = manage(serviceFactory.createGlobalsService());
+		dflFixtureService = manage(serviceFactory.createDflFixtureService());
+		dflTeamPredictedScoresService = manage(serviceFactory.createDflTeamPredictedScoresService());
+		dflPlayerService = manage(serviceFactory.createDflPlayerService());
+		insAndOutsService = manage(serviceFactory.createInsAndOutsService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
 	}
 
 	public void execute(int round, String emailOveride, boolean fromScoresCalculator) {
@@ -88,18 +88,11 @@ public class StartRoundHandler extends BaseHandler {
 			
 			loggerUtils.log("info", "Start round completed");
 			
-			dflTeamService.close();
-			globalsService.close();
-			dflFixtureService.close();
-			dflTeamPredictedScoresService.close();
-			dflPlayerService.close();
-			insAndOutsService.close();
-			dflTeamPlayerService.close();
-			dflRoundInfoService.close();
-			aflFixtureService.close();
 		
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in StartRoundHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 		
@@ -145,15 +138,7 @@ public class StartRoundHandler extends BaseHandler {
 		body = body + "<p>DFL Manager Admin</p>\n";
 		body = body + "</body>\n</html>";
 		
-		List<String> to = new ArrayList<>();
-		
-		if(emailOverride != null && !emailOverride.equals("")) {
-			to.add(emailOverride);
-		} else {
-			for(DflTeam team : teams) {
-				to.add(team.getCoachEmail());
-			}
-		}
+		List<String> to = EmailUtils.resolveRecipients(emailOverride, EmailUtils.coachEmails(teams));
 
 		loggerUtils.log("info", "Emailing early games start round to={}", to);
 		EmailUtils.sendHtmlEmail(to, dflMngrEmail, subject, body, null);	

--- a/src/main/java/net/dflmngr/handlers/StatsDownloaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StatsDownloaderHandler.java
@@ -23,9 +23,9 @@ public class StatsDownloaderHandler extends BaseHandler {
 
 	public StatsDownloaderHandler(int round, String statsUrl) {
 		super("RoundProgress");
-		rawPlayerStatsService = serviceFactory.createRawPlayerStatsService();
-		statsRoundPlayerStatsService = serviceFactory.createStatsRoundPlayerStatsService();
-		globalsService = serviceFactory.createGlobalsService();
+		rawPlayerStatsService = manage(serviceFactory.createRawPlayerStatsService());
+		statsRoundPlayerStatsService = manage(serviceFactory.createStatsRoundPlayerStatsService());
+		globalsService = manage(serviceFactory.createGlobalsService());
 
 		this.round = round;
 		this.statsUrl = statsUrl;
@@ -108,9 +108,7 @@ public class StatsDownloaderHandler extends BaseHandler {
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in StatsDownloaderHandler.execute(), homeTeam=" + homeTeam + " awayTeam=" + awayTeam, ex);
 		} finally {
-			rawPlayerStatsService.close();
-			statsRoundPlayerStatsService.close();
-			globalsService.close();
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/StatsHtmlHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StatsHtmlHandler.java
@@ -25,7 +25,7 @@ public class StatsHtmlHandler extends BaseHandler {
 
     public StatsHtmlHandler() {
         super("RoundProgress");
-        globalsService = serviceFactory.createGlobalsService();
+        globalsService = manage(serviceFactory.createGlobalsService());
     }
 
     public void configureLogging(String logfile) {
@@ -33,6 +33,15 @@ public class StatsHtmlHandler extends BaseHandler {
     }
 
     public List<RawPlayerStats> execute(int round, String homeTeam, String awayTeam, String statsUrl,
+            boolean includeHomeTeam, boolean includeAwayTeam, String scrapingStatus) {
+        try {
+            return doExecute(round, homeTeam, awayTeam, statsUrl, includeHomeTeam, includeAwayTeam, scrapingStatus);
+        } finally {
+            closeServices();
+        }
+    }
+
+    private List<RawPlayerStats> doExecute(int round, String homeTeam, String awayTeam, String statsUrl,
             boolean includeHomeTeam, boolean includeAwayTeam, String scrapingStatus) {
 
         ensureLoggingConfigured();

--- a/src/main/java/net/dflmngr/handlers/StatsRoundPlayerStatsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/StatsRoundPlayerStatsHandler.java
@@ -27,9 +27,9 @@ public class StatsRoundPlayerStatsHandler extends BaseHandler {
 
 	public StatsRoundPlayerStatsHandler() {
 		super("RawPlayerStatsHandler");
-		dflRoundInfoService = serviceFactory.createDflRoundInfoService();
-		aflFixtureService = serviceFactory.createAflFixtureService();
-		globalsService = serviceFactory.createGlobalsService();
+		dflRoundInfoService = manage(serviceFactory.createDflRoundInfoService());
+		aflFixtureService = manage(serviceFactory.createAflFixtureService());
+		globalsService = manage(serviceFactory.createGlobalsService());
 	}
 
 	public void execute(int round) {
@@ -57,14 +57,13 @@ public class StatsRoundPlayerStatsHandler extends BaseHandler {
 				}
 			}
 			
-			dflRoundInfoService.close();
-			aflFixtureService.close();
-			globalsService.close();
 
 			loggerUtils.log("info", "Stats round player stats downloaded");
 
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in StatsRoundPlayerStatsHandler.execute(), round=" + round, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
@@ -25,10 +25,10 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 
 	public TeamInsOutsLoaderHandler() {
 		super("Selections");
-		dflSelectedTeamService = serviceFactory.createDflSelectedTeamService();
-		dflTeamPlayerService = serviceFactory.createDflTeamPlayerService();
-		dflEarlyInsAndOutsService = serviceFactory.createDflEarlyInsAndOutsService();
-		insAndOutsService = serviceFactory.createInsAndOutsService();
+		dflSelectedTeamService = manage(serviceFactory.createDflSelectedTeamService());
+		dflTeamPlayerService = manage(serviceFactory.createDflTeamPlayerService());
+		dflEarlyInsAndOutsService = manage(serviceFactory.createDflEarlyInsAndOutsService());
+		insAndOutsService = manage(serviceFactory.createInsAndOutsService());
 	}
 
 	public void execute(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Double> emgs, boolean earlyGames) {
@@ -40,17 +40,15 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 			
 			if(earlyGames) {
 				handleEarlyGames(teamCode, round, ins, outs, emgs);
-				dflEarlyInsAndOutsService.close();
 			} else {
 				handleWithoutEarlyGames(teamCode, round, ins, outs, emgs);
-				insAndOutsService.close();
 			}
 
-			dflSelectedTeamService.close();
-			dflTeamPlayerService.close();
 						
 		} catch (Exception ex) {
 			loggerUtils.logException("Error in TeamInsOutsLoaderHandler.execute(), round=" + round + " teamCode=" + teamCode, ex);
+		} finally {
+			closeServices();
 		}
 	}
 

--- a/src/main/java/net/dflmngr/reports/InsAndOutsReport.java
+++ b/src/main/java/net/dflmngr/reports/InsAndOutsReport.java
@@ -344,15 +344,7 @@ public class InsAndOutsReport {
 		body = body + "<p>DFL Manager Admin</p>\n";
 		body = body + "</body>\n</html>";
 		
-		List<String> to = new ArrayList<>();
-
-		if(emailOverride != null && !emailOverride.equals("")) {
-			to.add(emailOverride);
-		} else {
-			for(DflTeam team : teams) {
-				to.add(team.getCoachEmail());
-			}
-		}
+		List<String> to = EmailUtils.resolveRecipients(emailOverride, EmailUtils.coachEmails(teams));
 		
 		List<String> attachments = new ArrayList<>();
 		attachments.add(reportName);

--- a/src/main/java/net/dflmngr/reports/RawStatsReport.java
+++ b/src/main/java/net/dflmngr/reports/RawStatsReport.java
@@ -175,13 +175,7 @@ public class RawStatsReport {
 				   "DFL Manager Admin";
 		}
 		
-		List<String> to = new ArrayList<>();
-		
-		if(emailOverride != null && !emailOverride.equals("")) {
-			to.add(emailOverride);
-		} else {
-			to.add(dflGroupEmail);
-		}
+		List<String> to = EmailUtils.resolveRecipients(emailOverride, List.of(dflGroupEmail));
 		
 		List<String> attachments = new ArrayList<>();
 		attachments.add(reportName);

--- a/src/main/java/net/dflmngr/reports/ResultsReport.java
+++ b/src/main/java/net/dflmngr/reports/ResultsReport.java
@@ -832,16 +832,7 @@ public class ResultsReport {
 			body = createEmailBody(round);
 		}
 		
-		List<String> to = new ArrayList<>();
-
-		if(emailOverride != null && !emailOverride.equals("")) {
-			to.add(emailOverride);
-		} else {
-			List<DflTeam> teams = dflTeamService.findAll();
-			for(DflTeam team : teams) {
-				to.add(team.getCoachEmail());
-			}
-		}
+		List<String> to = EmailUtils.resolveRecipients(emailOverride, EmailUtils.coachEmails(dflTeamService.findAll()));
 		
 		List<String> attachments = new ArrayList<>();
 		attachments.add(reportName);

--- a/src/main/java/net/dflmngr/utils/EmailUtils.java
+++ b/src/main/java/net/dflmngr/utils/EmailUtils.java
@@ -1,5 +1,6 @@
 package net.dflmngr.utils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -45,6 +46,24 @@ public class EmailUtils {
 
 	private EmailUtils() {
 		throw new IllegalStateException("Utility class");
+	}
+
+	public static List<String> resolveRecipients(String emailOverride, List<String> defaultRecipients) {
+		List<String> to = new ArrayList<>();
+		if(emailOverride != null && !emailOverride.equals("")) {
+			to.add(emailOverride);
+		} else {
+			to.addAll(defaultRecipients);
+		}
+		return to;
+	}
+
+	public static List<String> coachEmails(List<net.dflmngr.model.entity.DflTeam> teams) {
+		List<String> emails = new ArrayList<>();
+		for(net.dflmngr.model.entity.DflTeam team : teams) {
+			emails.add(team.getCoachEmail());
+		}
+		return emails;
 	}
 
 	public static void sendTextEmail(List<String> to, String from, String subject, String body, List<String> attachments) {


### PR DESCRIPTION
## Summary

Third of four refactoring PRs — **merge after #259** (stacked; I'll rebase after each merge).

- `BaseHandler` gains `manage()` / `closeServices()`: handlers register services at creation (`manage(serviceFactory.createXxx())`) and close them all in a `finally`. This removes ~25 hand-written close blocks and fixes the handlers that never closed their services at all (AflFixtureLoader, AflGameCompletionChecker, DflRoundInfoCalculator, PreSeasonStats, StatsHtml, …).
- Handlers whose `execute()` propagates exceptions (StatsHtmlHandler, PreSeasonStatsHandler, AflFixtureLoaderHandler) use a thin `execute()`→`doExecute()` wrapper so cleanup still runs.
- `AflFixtureHtmlHandler` / `AflPlayerLoaderHtmlHandler` are reused across multiple `execute()` calls by their owning loaders, so they deliberately keep services open (same as before).
- `EmailUtils.resolveRecipients()` + `coachEmails()` replace the `emailOverride` recipient-building block copy-pasted in StartRoundHandler, EndRoundHandler, InsAndOutsReport, RawStatsReport, and ResultsReport.

## Tests

Full suite: 146 tests, 0 failures.