### PR TITLE
Replace Double emergency encoding with an Emergency record

### DIFF
--- a/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
+++ b/src/main/java/net/dflmngr/handlers/EmailSelectionsHandler.java
@@ -42,6 +42,7 @@ import net.dflmngr.model.service.DflTeamService;
 import net.dflmngr.model.service.GlobalsService;
 import net.dflmngr.utils.DflmngrUtils;
 import net.dflmngr.utils.oauth2.OAuth2Authenticator;
+import net.dflmngr.validation.Emergency;
 import net.dflmngr.validation.SelectedTeamValidation;
 import net.freeutils.tnef.Attachment;
 import net.freeutils.tnef.TNEFInputStream;
@@ -424,7 +425,7 @@ if (content instanceof InputStream || content instanceof String) {
 		private int round = 0;
 		private final List<Integer> ins = new ArrayList<>();
 		private final List<Integer> outs = new ArrayList<>();
-		private final List<Double> emgs = new ArrayList<>();
+		private final List<Emergency> emgs = new ArrayList<>();
 	}
 
 	private SelectedTeamValidation handleSelectionEmailText(String[] emailLines, String id) {
@@ -564,15 +565,10 @@ if (content instanceof InputStream || content instanceof String) {
 					} else if (line.isEmpty()) {
 						// ignore blank lines
 					} else {
-						double emg = getPlayerNo(line);
+						int emg = getPlayerNo(line);
 						if (emg > 0) {
-							if (emgCount == 1) {
-								emg = emg + 0.1;
-								emgCount++;
-							} else {
-								emg = emg + 0.2;
-							}
-							parsed.emgs.add(emg);
+							parsed.emgs.add(new Emergency(emg, emgCount == 1 ? 1 : 2));
+							emgCount++;
 						} else {
 							loggerUtils.log("debug", "Couldn't get player number for emergencies, No.={}", emg);
 						}

--- a/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
+++ b/src/main/java/net/dflmngr/handlers/SelectedTeamValidationHandler.java
@@ -19,6 +19,7 @@ import net.dflmngr.model.service.DflSelectedTeamService;
 import net.dflmngr.model.service.DflSelectionIdsService;
 import net.dflmngr.model.service.DflTeamPlayerService;
 import net.dflmngr.model.service.GlobalsService;
+import net.dflmngr.validation.Emergency;
 import net.dflmngr.validation.SelectedTeamValidation;
 
 public class SelectedTeamValidationHandler extends BaseHandler {
@@ -44,7 +45,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		dflSelectionIdsService = manage(serviceFactory.createDflSelectionIdsService());
 	}
 
-	public SelectedTeamValidation execute(int round, String teamCode, Map<String, List<Integer>> insAndOuts, List<Double> emergencies, String selectionId) {
+	public SelectedTeamValidation execute(int round, String teamCode, Map<String, List<Integer>> insAndOuts, List<Emergency> emergencies, String selectionId) {
 
 		SelectedTeamValidation validationResult = null;
 
@@ -86,7 +87,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		return validationResult;
 	}
 
-	private SelectedTeamValidation standardValidation(int round, int currentRound, String teamCode, Map<String, List<Integer>> insAndOuts, List<Double> emergencies, String selectionId) {
+	private SelectedTeamValidation standardValidation(int round, int currentRound, String teamCode, Map<String, List<Integer>> insAndOuts, List<Emergency> emergencies, String selectionId) {
 
 		SelectedTeamValidation validationResult = new SelectedTeamValidation();
 
@@ -99,7 +100,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 
 		List<Integer> checkedIns = new ArrayList<>();
 		List<Integer> checkedOuts = new ArrayList<>();
-		List<Double> checkedEmgs = new ArrayList<>();
+		List<Emergency> checkedEmgs = new ArrayList<>();
 		boolean playerNumbersOk = true;
 
 		List<DflPlayer> selectedWarnPlayers = new ArrayList<>();
@@ -183,8 +184,8 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 					}
 				}
 
-				for(Double emg : emergencies) {
-					int emergency = emg.intValue();
+				for(Emergency emg : emergencies) {
+					int emergency = emg.playerNo();
 
 					if(emergency < 1 || emergency > 45) {
 						loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
@@ -211,14 +212,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 						selectedPlayer.setRound(round);
 						selectedPlayer.setTeamCode(teamCode);
 						selectedPlayer.setTeamPlayerId(emergency);
-
-						int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
-						if(e1e2 == 1) {
-							selectedPlayer.setEmergency(1);
-						} else {
-							selectedPlayer.setEmergency(2);
-						}
-
+						selectedPlayer.setEmergency(emg.rank());
 						selectedPlayer.setDnp(false);
 
 						selectedTeam.add(selectedPlayer);
@@ -337,8 +331,8 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 					}
 				}
 
-				for(Double emg : emergencies) {
-					int emergency = emg.intValue();
+				for(Emergency emg : emergencies) {
+					int emergency = emg.playerNo();
 
 					if(emergency < 1 || emergency > 45) {
 						loggerUtils.log("info", "Emergency player outside player range, teamPlayerId={}.", emergency);
@@ -376,13 +370,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 							selectedPlayer.setTeamCode(teamCode);
 							selectedPlayer.setTeamPlayerId(emergency);
 
-							int e1e2 = Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1));
-							if(e1e2 == 1) {
-								selectedPlayer.setEmergency(1);
-							} else {
-								selectedPlayer.setEmergency(2);
-							}
-
+							selectedPlayer.setEmergency(emg.rank());
 							selectedPlayer.setDnp(false);
 
 							selectedTeam.add(selectedPlayer);
@@ -524,7 +512,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 		}
 
 		if(positionCounts.anyOverLimit()) {
-			List<Double> emgs = validationResult.getEmergencies();
+			List<Emergency> emgs = validationResult.getEmergencies();
 			for(DflPlayer player : emgPlayers) {
 				String pos = player.getPosition().toLowerCase();
 
@@ -533,7 +521,7 @@ public class SelectedTeamValidationHandler extends BaseHandler {
 					loggerUtils.log("info", "Invalid emergency, player={};", player);
 
 					DflTeamPlayer teamPlayer = dflTeamPlayerService.get(player.getPlayerId());
-					int emg1 = emgs.size() >= 1 ? emgs.get(0).intValue() : 0;
+					int emg1 = !emgs.isEmpty() ? emgs.get(0).playerNo() : 0;
 
 					if(emg1 == teamPlayer.getTeamPlayerId()) {
 						emgs.remove(0);

--- a/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
+++ b/src/main/java/net/dflmngr/handlers/TeamInsOutsLoaderHandler.java
@@ -15,6 +15,7 @@ import net.dflmngr.model.service.DflEarlyInsAndOutsService;
 import net.dflmngr.model.service.DflSelectedTeamService;
 import net.dflmngr.model.service.DflTeamPlayerService;
 import net.dflmngr.model.service.InsAndOutsService;
+import net.dflmngr.validation.Emergency;
 
 public class TeamInsOutsLoaderHandler extends BaseHandler {
 
@@ -31,7 +32,7 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 		insAndOutsService = manage(serviceFactory.createInsAndOutsService());
 	}
 
-	public void execute(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Double> emgs, boolean earlyGames) {
+	public void execute(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Emergency> emgs, boolean earlyGames) {
 
 		try {
 			ensureLoggingConfigured();
@@ -52,7 +53,7 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 		}
 	}
 
-	private void handleEarlyGames(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Double> emgs) {
+	private void handleEarlyGames(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Emergency> emgs) {
 		loggerUtils.log("info", "Early Games, saving to early games ins and outs");
 
 		List<DflEarlyInsAndOuts> earlyInsAndOuts = new ArrayList<>();
@@ -66,7 +67,7 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 		loggerUtils.log("info", "Ins and outs saved");
 	}
 
-	private void handleWithoutEarlyGames(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Double> emgs) {
+	private void handleWithoutEarlyGames(String teamCode, int round, List<Integer> ins, List<Integer> outs, List<Emergency> emgs) {
 		loggerUtils.log("info", "Not early games, saving to regular ins and outs");
 
 		List<InsAndOuts> insAndOuts = new ArrayList<>();
@@ -118,15 +119,15 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 		return earlyOuts;
 	}
 
-	private List<DflEarlyInsAndOuts> setEarlyEmgs(String teamCode, int round, List<Double> emgs) {
+	private List<DflEarlyInsAndOuts> setEarlyEmgs(String teamCode, int round, List<Emergency> emgs) {
 		List<DflEarlyInsAndOuts> earlyEmgs = new ArrayList<>();
 
-		for(Double e : emgs) {
+		for(Emergency e : emgs) {
 			DflEarlyInsAndOuts emg = new DflEarlyInsAndOuts();
 			emg.setRound(round);
 			emg.setTeamCode(teamCode);
 
-			int eid = e.intValue();
+			int eid = e.playerNo();
 			emg.setTeamPlayerId(eid);
 			emg.setInOrOut(DomainDecodes.INS_AND_OUTS.IN_OR_OUT.EMG1);
 
@@ -168,15 +169,15 @@ public class TeamInsOutsLoaderHandler extends BaseHandler {
 		return fullOuts;
 	}
 
-	private List<InsAndOuts> setEmgs(String teamCode, int round, List<Double> emgs) {
+	private List<InsAndOuts> setEmgs(String teamCode, int round, List<Emergency> emgs) {
 		List<InsAndOuts> fullEmgs = new ArrayList<>();
 
-		for(Double e : emgs) {
+		for(Emergency e : emgs) {
 			InsAndOuts emg = new InsAndOuts();
 			emg.setRound(round);
 			emg.setTeamCode(teamCode);
 
-			int eid = e.intValue();
+			int eid = e.playerNo();
 			emg.setTeamPlayerId(eid);
 			emg.setInOrOut(DomainDecodes.INS_AND_OUTS.IN_OR_OUT.EMG1);
 

--- a/src/main/java/net/dflmngr/validation/Emergency.java
+++ b/src/main/java/net/dflmngr/validation/Emergency.java
@@ -1,0 +1,11 @@
+package net.dflmngr.validation;
+
+/**
+ * An emergency selection: the team player number (1-45) and the emergency
+ * rank (1 = first emergency, 2 = any subsequent emergency).
+ *
+ * Replaces the old encoding where 21.1/21.2 meant "player 21, emergency 1/2"
+ * packed into a Double and decoded from its decimal digits.
+ */
+public record Emergency(int playerNo, int rank) {
+}

--- a/src/main/java/net/dflmngr/validation/SelectedTeamValidation.java
+++ b/src/main/java/net/dflmngr/validation/SelectedTeamValidation.java
@@ -41,7 +41,7 @@ public class SelectedTeamValidation {
 	private String from;
 	
 	private Map<String, List<Integer>> insAndOuts;
-	private List<Double> emergencies;
+	private List<Emergency> emergencies;
 	
 	public List<DflPlayer> ffPlayers;
 	public List<DflPlayer> fwdPlayers;
@@ -136,11 +136,11 @@ public class SelectedTeamValidation {
 		this.insAndOuts = insAndOuts;
 	}
 	
-	public List<Double> getEmergencies() {
+	public List<Emergency> getEmergencies() {
 		return emergencies;
 	}
 
-	public void setEmergencies(List<Double> emergencies) {
+	public void setEmergencies(List<Emergency> emergencies) {
 		this.emergencies = emergencies;
 	}
 

--- a/src/test/java/net/dflmngr/handlers/SelectedTeamValidationHandlerTest.java
+++ b/src/test/java/net/dflmngr/handlers/SelectedTeamValidationHandlerTest.java
@@ -41,6 +41,7 @@ import net.dflmngr.model.service.DflSelectionIdsService;
 import net.dflmngr.model.service.DflTeamPlayerService;
 import net.dflmngr.model.service.GlobalsService;
 import net.dflmngr.service.ServiceFactory;
+import net.dflmngr.validation.Emergency;
 import net.dflmngr.validation.SelectedTeamValidation;
 
 @ExtendWith(MockitoExtension.class)
@@ -194,7 +195,7 @@ class SelectedTeamValidationHandlerTest {
 
 		SelectedTeamValidation result = handler.execute(2, TEAM_CODE,
 				insAndOuts(new ArrayList<>(), new ArrayList<>()),
-				new ArrayList<>(List.of(7.1)), "noid");
+				new ArrayList<>(List.of(new Emergency(7, 1))), "noid");
 
 		assertNotNull(result);
 		// the already-selected emergency must not be added to the team again:

--- a/src/test/java/net/dflmngr/validation/SelectedTeamValidationTest.java
+++ b/src/test/java/net/dflmngr/validation/SelectedTeamValidationTest.java
@@ -296,9 +296,9 @@ class SelectedTeamValidationTest {
 
 	@Test
 	void emergenciesGetterSetter_shouldWorkCorrectly() {
-		List<Double> emergencies = new ArrayList<>();
-		emergencies.add(1.0);
-		emergencies.add(2.0);
+		List<Emergency> emergencies = new ArrayList<>();
+		emergencies.add(new Emergency(1, 1));
+		emergencies.add(new Emergency(2, 2));
 
 		validation.setEmergencies(emergencies);
 


### PR DESCRIPTION
## Summary

Last of four refactoring PRs — **merge after #260** (stacked; I'll rebase after each merge).

Emergencies travelled through the selections pipeline as `List<Double>`, where `21.1`/`21.2` meant "player 21, emergency 1/2" — encoded by adding `0.1`/`0.2` and decoded via `Integer.parseInt(Double.toString(emg).split("\\.")[1].substring(0, 1))`. That only works because Java prints shortest-representation doubles.

`Emergency(int playerNo, int rank)` replaces it across `EmailSelectionsHandler`, `SelectedTeamValidationHandler`, `SelectedTeamValidation`, and `TeamInsOutsLoaderHandler`.

### Observation (behavior preserved, question for later)

`TeamInsOutsLoaderHandler.setEmgs`/`setEarlyEmgs` write **every** emergency as `EMG1` ("E1") — the e1/e2 rank from the coach's email has always been discarded at persistence (`DomainDecodes` doesn't even define an EMG2 constant, though `selectEmg`/`applyEmg` have dead else-branches that would map it to emergency 2). This PR preserves that behavior exactly; if the rank *should* be persisted, that's a one-line follow-up now that the record carries it.

## Tests

Full suite: 146 tests, 0 failures. Handler regression tests updated to construct `Emergency(7, 1)` instead of `7.1`.