### PR TITLE
Bump jackson-databind to 2.22.1 to fix deserialization CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<!-- Dependency versions -->
 		<eclipselink.version>5.0.0-B13</eclipselink.version>
 		<log4j.version>2.25.4</log4j.version>
-		<jackson.version>2.22.0</jackson.version>
+		<jackson.version>2.22.1</jackson.version>
 		<selenium.version>4.39.0</selenium.version>
 		<poi.version>5.5.1</poi.version>
 		<quartz.version>2.5.2</quartz.version>


### PR DESCRIPTION
## Summary

Fixes the open Dependabot alert (dependabot/35, moderate): jackson-databind 2.22.0 — which #255 bumped to — is vulnerable to case-insensitive deserialization bypassing per-property `@JsonIgnoreProperties` (affected range `>= 2.22.0, < 2.22.1`). 2.22.1 is the patched release; Dependabot hadn't raised the follow-up PR yet.

One-line `jackson.version` property bump.

## Tests

Full suite: 146 tests, 0 failures.